### PR TITLE
Add KYC review workflow: account type, document review, admin panel, feature gating

### DIFF
--- a/app/AllowedIps.php
+++ b/app/AllowedIps.php
@@ -1,0 +1,123 @@
+<?php
+/**
+ * ELLSMS — organization-level allowed-IP management (§20 of the KYC phase brief, docs/profile-kyc.md).
+ *
+ * MANAGEMENT ONLY. This file lets an organization record which IPs/CIDR ranges it expects its own
+ * traffic to come from, and audits every change. It deliberately does NOT enforce anything against
+ * login or API requests — the phase brief is explicit that global enforcement is added only "if the
+ * project already has a clear safe hook," and ELLSMS's login path (app/authorization.php,
+ * app/rate_limit.php) has no such hook today. Wiring enforcement in blind would risk locking
+ * administrators out mid-migration, which the brief explicitly forbids. See docs/profile-kyc.md
+ * §Allowed IP management for the exact, honest statement of what is and is not enforced.
+ */
+
+declare(strict_types=1);
+
+/** Raised for any allowed-IP validation failure; ->getMessage() is safe to show (AppException semantics). */
+class AllowedIpException extends AppException {}
+
+/**
+ * Validates a plain IPv4/IPv6 address or an address with a /prefix (CIDR). Returns the normalized
+ * string (lowercase, no surrounding whitespace) or null if the input is not a valid address/CIDR.
+ */
+function allowed_ip_normalize(string $raw): ?string {
+    $raw = strtolower(trim(from_persian_digits($raw)));
+    if ($raw === '') {
+        return null;
+    }
+    if (!str_contains($raw, '/')) {
+        return filter_var($raw, FILTER_VALIDATE_IP) !== false ? $raw : null;
+    }
+
+    [$address, $prefix] = array_pad(explode('/', $raw, 2), 2, '');
+    if (!ctype_digit($prefix)) {
+        return null;
+    }
+    $prefix = (int)$prefix;
+    if (filter_var($address, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4) !== false) {
+        return $prefix >= 0 && $prefix <= 32 ? "{$address}/{$prefix}" : null;
+    }
+    if (filter_var($address, FILTER_VALIDATE_IP, FILTER_FLAG_IPV6) !== false) {
+        return $prefix >= 0 && $prefix <= 128 ? "{$address}/{$prefix}" : null;
+    }
+    return null;
+}
+
+/** @return list<array<string,mixed>> newest first */
+function allowed_ip_list(int $organizationId): array {
+    if ($organizationId <= 0) {
+        return [];
+    }
+    $st = db()->prepare('SELECT * FROM ellsms_organization_allowed_ips WHERE organization_id = ? ORDER BY id DESC');
+    $st->execute([$organizationId]);
+    return $st->fetchAll();
+}
+
+function allowed_ip_create(int $organizationId, string $ipOrCidr, string $label, int $actorUserId): array {
+    if ($organizationId <= 0) {
+        return ['ok' => false, 'reason' => 'invalid_organization'];
+    }
+    $normalized = allowed_ip_normalize($ipOrCidr);
+    if ($normalized === null) {
+        return ['ok' => false, 'reason' => 'invalid_ip'];
+    }
+    $label = profile_clean_text($label, 120);
+
+    try {
+        db()->prepare(
+            'INSERT INTO ellsms_organization_allowed_ips (organization_id, ip_or_cidr, label, created_by_user_id)
+             VALUES (?,?,?,?)'
+        )->execute([$organizationId, $normalized, $label, $actorUserId]);
+    } catch (PDOException $e) {
+        // uniq_org_ip — the same address already exists for this organization.
+        return ['ok' => false, 'reason' => 'duplicate'];
+    }
+
+    $id = (int)db()->lastInsertId();
+    audit($actorUserId, 'allowed_ip.created', "org={$organizationId} id={$id} ip={$normalized}");
+    Logger::info('allowed_ip.created', ['organization_id' => $organizationId, 'id' => $id]);
+    return ['ok' => true, 'id' => $id];
+}
+
+function allowed_ip_delete(int $organizationId, int $id, int $actorUserId): array {
+    if ($organizationId <= 0 || $id <= 0) {
+        return ['ok' => false, 'reason' => 'not_found'];
+    }
+    $st = db()->prepare('SELECT id FROM ellsms_organization_allowed_ips WHERE id = ? AND organization_id = ?');
+    $st->execute([$id, $organizationId]);
+    if (!$st->fetch()) {
+        return ['ok' => false, 'reason' => 'not_found'];
+    }
+    db()->prepare('DELETE FROM ellsms_organization_allowed_ips WHERE id = ? AND organization_id = ?')
+        ->execute([$id, $organizationId]);
+
+    audit($actorUserId, 'allowed_ip.deleted', "org={$organizationId} id={$id}");
+    Logger::info('allowed_ip.deleted', ['organization_id' => $organizationId, 'id' => $id]);
+    return ['ok' => true];
+}
+
+function allowed_ip_toggle(int $organizationId, int $id, int $actorUserId): array {
+    if ($organizationId <= 0 || $id <= 0) {
+        return ['ok' => false, 'reason' => 'not_found'];
+    }
+    $st = db()->prepare('SELECT status FROM ellsms_organization_allowed_ips WHERE id = ? AND organization_id = ?');
+    $st->execute([$id, $organizationId]);
+    $row = $st->fetch();
+    if (!$row) {
+        return ['ok' => false, 'reason' => 'not_found'];
+    }
+    $newStatus = $row['status'] === 'active' ? 'disabled' : 'active';
+    db()->prepare('UPDATE ellsms_organization_allowed_ips SET status = ? WHERE id = ? AND organization_id = ?')
+        ->execute([$newStatus, $id, $organizationId]);
+    audit($actorUserId, 'allowed_ip.updated', "org={$organizationId} id={$id} status={$newStatus}");
+    return ['ok' => true, 'status' => $newStatus];
+}
+
+function allowed_ip_error_message(string $reason): string {
+    return [
+        'invalid_organization' => 'سازمان فعالی برای این عملیات وجود ندارد.',
+        'invalid_ip'            => 'آدرس IP یا محدوده‌ی CIDR معتبر نیست.',
+        'duplicate'             => 'این آدرس قبلاً ثبت شده است.',
+        'not_found'             => 'مورد یافت نشد.',
+    ][$reason] ?? 'ذخیره‌سازی ممکن نشد.';
+}

--- a/app/Kyc.php
+++ b/app/Kyc.php
@@ -1,0 +1,346 @@
+<?php
+/**
+ * ELLSMS — KYC review workflow: state machine, per-document review, submission eligibility, and
+ * centralized feature gating (docs/profile-kyc.md).
+ *
+ * Builds directly on app/Profile.php (docs/customer-profile.md), which deliberately stopped short of
+ * a review workflow: "Documents are stored, replaced and archived; nothing reviews or approves them."
+ * This file is exactly that missing piece, and nothing more — it does not touch document storage,
+ * upload validation, or the personal/company field model, all of which stay owned by Profile.php.
+ *
+ * OWNERSHIP: one ellsms_kyc_requests row per ORGANIZATION (the account/tenant boundary), covering
+ * both individual and legal accounts — the same boundary account_type itself lives on
+ * (ellsms_organization_profiles.organization_id). A row is created lazily, on first read, so an
+ * organization that never touches KYC has no row and is completely unaffected by this feature.
+ *
+ * RBAC: exactly like the pre-existing KYC surface (public/users.php's kyc_save, public/kyc-photo.php),
+ * every admin-facing action in this file is PLATFORM-ADMIN-ONLY (require_admin() at the call site,
+ * never delegated to an organization role) — Permissions::KYC_VIEW / KYC_MANAGE stay RESERVED exactly
+ * as app/rbac.php already documents ("nobody but platform admin gets those"). This phase does not
+ * reopen that decision; see docs/profile-kyc.md §RBAC for the full reasoning.
+ */
+
+declare(strict_types=1);
+
+/* ==========================================================================
+   State machine catalog
+   ========================================================================== */
+
+const KYC_STATUSES = [
+    'draft'             => 'احراز نشده',
+    'submitted'         => 'ارسال شده',
+    'under_review'      => 'در حال بررسی',
+    'needs_correction'  => 'نیازمند اصلاح',
+    'approved'          => 'تأیید شده',
+    'rejected'          => 'رد شده',
+];
+
+/** Every allowed transition, explicit — anything not listed here is refused, never silently allowed. */
+const KYC_TRANSITIONS = [
+    'draft'            => ['submitted'],
+    'submitted'        => ['under_review'],
+    'under_review'     => ['approved', 'needs_correction', 'rejected'],
+    'needs_correction' => ['submitted'],
+    'rejected'         => ['submitted'],
+    'approved'         => [],
+];
+
+const KYC_DOCUMENT_REVIEW_STATUSES = [
+    'pending'  => 'در انتظار بررسی',
+    'approved' => 'تأیید شده',
+    'rejected' => 'رد شده',
+];
+
+function kyc_status_label(string $status): string {
+    return KYC_STATUSES[$status] ?? $status;
+}
+
+function kyc_document_review_status_label(string $status): string {
+    return KYC_DOCUMENT_REVIEW_STATUSES[$status] ?? $status;
+}
+
+/** Raised for any KYC validation/transition failure; ->getMessage() is safe to show (AppException semantics). */
+class KycException extends AppException {}
+
+/* ==========================================================================
+   Request read/write
+   ========================================================================== */
+
+/** Always an array — an organization with no row yet reads as a fresh 'draft' request, never null. */
+function kyc_request_get(int $organizationId): array {
+    $empty = [
+        'organization_id' => $organizationId, 'status' => 'draft',
+        'submitted_at' => null, 'review_started_at' => null, 'reviewed_at' => null,
+        'reviewed_by_user_id' => null, 'review_note' => '',
+    ];
+    if ($organizationId <= 0) {
+        return $empty;
+    }
+    try {
+        $st = db()->prepare('SELECT * FROM ellsms_kyc_requests WHERE organization_id = ?');
+        $st->execute([$organizationId]);
+        return $st->fetch() ?: $empty;
+    } catch (Throwable $t) {
+        Logger::error('kyc.request_get_failed', ['organization_id' => $organizationId, 'exception' => $t]);
+        return $empty;
+    }
+}
+
+/**
+ * The single choke point every status change goes through — no call site anywhere is allowed to
+ * UPDATE ellsms_kyc_requests.status directly, so KYC_TRANSITIONS is the only place "what's allowed
+ * next" is decided (§7: "Do not allow arbitrary status mutation").
+ */
+function kyc_transition(int $organizationId, string $toStatus, int $actorUserId, string $note = ''): array {
+    if ($organizationId <= 0) {
+        return ['ok' => false, 'reason' => 'invalid_organization'];
+    }
+    if (!array_key_exists($toStatus, KYC_STATUSES)) {
+        return ['ok' => false, 'reason' => 'invalid_status'];
+    }
+
+    return db_transaction(function (PDO $db) use ($organizationId, $toStatus, $actorUserId, $note): array {
+        $st = $db->prepare('SELECT * FROM ellsms_kyc_requests WHERE organization_id = ? FOR UPDATE');
+        $st->execute([$organizationId]);
+        $current = $st->fetch();
+        $fromStatus = $current ? (string)$current['status'] : 'draft';
+
+        if (!in_array($toStatus, KYC_TRANSITIONS[$fromStatus] ?? [], true)) {
+            return ['ok' => false, 'reason' => 'invalid_transition', 'from' => $fromStatus];
+        }
+
+        $note = profile_clean_text($note, 1000);
+        $sets = ['status = ?'];
+        $params = [$toStatus];
+
+        if ($toStatus === 'submitted') {
+            $sets[] = 'submitted_at = UTC_TIMESTAMP()';
+            $sets[] = 'review_started_at = NULL';
+            $sets[] = 'reviewed_at = NULL';
+            $sets[] = "review_note = ''";
+        } elseif ($toStatus === 'under_review') {
+            $sets[] = 'review_started_at = UTC_TIMESTAMP()';
+            $sets[] = 'reviewed_by_user_id = ?';
+            $params[] = $actorUserId;
+        } elseif (in_array($toStatus, ['approved', 'needs_correction', 'rejected'], true)) {
+            $sets[] = 'reviewed_at = UTC_TIMESTAMP()';
+            $sets[] = 'reviewed_by_user_id = ?';
+            $sets[] = 'review_note = ?';
+            $params[] = $actorUserId;
+            $params[] = $note;
+        }
+
+        $db->prepare(
+            "INSERT INTO ellsms_kyc_requests (organization_id, status) VALUES (?, 'draft')
+             ON DUPLICATE KEY UPDATE organization_id = organization_id"
+        )->execute([$organizationId]);
+        $db->prepare('UPDATE ellsms_kyc_requests SET ' . implode(', ', $sets) . ' WHERE organization_id = ?')
+           ->execute([...$params, $organizationId]);
+
+        $auditAction = [
+            'submitted'        => 'kyc.submitted',
+            'under_review'     => 'kyc.review_started',
+            'approved'         => 'kyc.approved',
+            'needs_correction' => 'kyc.needs_correction',
+            'rejected'         => 'kyc.rejected',
+        ][$toStatus] ?? 'kyc.status_changed';
+        // Review notes are shown back to the customer verbatim (escaped at render) but are NEVER
+        // written into the audit trail themselves — a review note can legitimately reference
+        // sensitive specifics ("national code photo is blurry"), and the audit log is not the place
+        // for a second copy of that text (§19/§28, mirrors profile_mask_identifier's own reasoning).
+        audit($actorUserId, $auditAction, "org={$organizationId} from={$fromStatus} to={$toStatus}");
+        Logger::info('kyc.transitioned', ['organization_id' => $organizationId, 'from' => $fromStatus, 'to' => $toStatus, 'actor_user_id' => $actorUserId]);
+
+        return ['ok' => true, 'from' => $fromStatus, 'to' => $toStatus];
+    });
+}
+
+/* ==========================================================================
+   Submission eligibility (§16) — ONE centralized check, never duplicated between UI and backend
+   ========================================================================== */
+
+/**
+ * @return array{ok:bool, missing:list<string>}
+ */
+function kyc_can_submit(int $organizationId, int $userId, string $accountType, array $userProfile, array $organizationProfile, array $address): array {
+    $missing = [];
+
+    if ($accountType === 'legal') {
+        foreach (['legal_name', 'national_id', 'ceo_name', 'ceo_national_code'] as $field) {
+            if (($organizationProfile[$field] ?? '') === '') {
+                $missing[] = 'اطلاعات سازمان/نماینده ناقص است';
+                break;
+            }
+        }
+        $requiredDocs = PROFILE_REQUIRED_DOCUMENTS_LEGAL;
+        $documents = profile_documents_list(['organization' => $organizationId], false);
+    } else {
+        foreach (['father_name', 'national_code'] as $field) {
+            if (($userProfile[$field] ?? '') === '') {
+                $missing[] = 'اطلاعات فردی ناقص است';
+                break;
+            }
+        }
+        $requiredDocs = PROFILE_REQUIRED_DOCUMENTS_INDIVIDUAL;
+        $documents = profile_documents_list(['user' => $userId], false);
+    }
+
+    if (($address['postal_code'] ?? '') === '' || ($address['city'] ?? '') === '') {
+        $missing[] = 'آدرس ناقص است';
+    }
+
+    $presentTypes = array_column($documents, 'document_type');
+    foreach ($requiredDocs as $type) {
+        if (!in_array($type, $presentTypes, true)) {
+            $missing[] = 'مدرک «' . profile_document_type_label($type) . '» بارگذاری نشده است';
+        }
+    }
+
+    return ['ok' => $missing === [], 'missing' => $missing];
+}
+
+/**
+ * The one action the self-service profile page calls. Re-validates eligibility itself (never trusts
+ * the caller already checked) and re-uses kyc_transition() so the same state machine guard applies
+ * here as everywhere else.
+ */
+function kyc_submit(int $organizationId, int $userId, string $accountType, array $userProfile, array $organizationProfile, array $address): array {
+    $eligibility = kyc_can_submit($organizationId, $userId, $accountType, $userProfile, $organizationProfile, $address);
+    if (!$eligibility['ok']) {
+        return ['ok' => false, 'reason' => 'incomplete', 'missing' => $eligibility['missing']];
+    }
+    $result = kyc_transition($organizationId, 'submitted', $userId);
+    if (!$result['ok']) {
+        return ['ok' => false, 'reason' => $result['reason'] ?? 'invalid_transition'];
+    }
+    return ['ok' => true];
+}
+
+/* ==========================================================================
+   Per-document review (§9/§17) — admin-only, enforced by the caller (require_admin())
+   ========================================================================== */
+
+function kyc_document_review(int $documentId, string $reviewStatus, int $actorUserId, string $note = ''): array {
+    if (!array_key_exists($reviewStatus, KYC_DOCUMENT_REVIEW_STATUSES) || $reviewStatus === 'pending') {
+        return ['ok' => false, 'reason' => 'invalid_status'];
+    }
+    $document = profile_document_find($documentId);
+    if ($document === null) {
+        return ['ok' => false, 'reason' => 'not_found'];
+    }
+    $note = profile_clean_text($note, 500);
+
+    db()->prepare(
+        'UPDATE ellsms_profile_documents
+         SET review_status = ?, reviewed_at = UTC_TIMESTAMP(), reviewed_by_user_id = ?, review_note = ?
+         WHERE id = ?'
+    )->execute([$reviewStatus, $actorUserId, $note, $documentId]);
+
+    $auditAction = $reviewStatus === 'approved' ? 'kyc.document_approved' : 'kyc.document_rejected';
+    $ownerRef = $document['organization_id'] !== null
+        ? 'org=#' . $document['organization_id']
+        : 'user=#' . $document['user_id'];
+    audit($actorUserId, $auditAction, "{$ownerRef} type={$document['document_type']} id={$documentId}");
+    Logger::info('kyc.document_reviewed', ['document_id' => $documentId, 'review_status' => $reviewStatus, 'actor_user_id' => $actorUserId]);
+    return ['ok' => true];
+}
+
+/* ==========================================================================
+   Admin listing/search (§17)
+   ========================================================================== */
+
+/**
+ * @return list<array<string,mixed>>
+ */
+function kyc_requests_list(?string $statusFilter = null, string $search = '', int $limit = 100): array {
+    $sql = "SELECT r.*, o.name AS organization_name, op.account_type, op.legal_name
+            FROM ellsms_kyc_requests r
+            JOIN ellsms_organizations o ON o.id = r.organization_id
+            LEFT JOIN ellsms_organization_profiles op ON op.organization_id = r.organization_id
+            WHERE 1=1";
+    $params = [];
+    if ($statusFilter !== null && $statusFilter !== '' && array_key_exists($statusFilter, KYC_STATUSES)) {
+        $sql .= ' AND r.status = ?';
+        $params[] = $statusFilter;
+    }
+    $search = trim($search);
+    if ($search !== '') {
+        $sql .= ' AND (o.name LIKE ? OR op.legal_name LIKE ? OR r.organization_id = ?)';
+        $like = '%' . $search . '%';
+        $params[] = $like;
+        $params[] = $like;
+        $params[] = ctype_digit($search) ? (int)$search : -1;
+    }
+    $sql .= ' ORDER BY (r.submitted_at IS NULL), r.submitted_at DESC, r.organization_id DESC LIMIT ' . max(1, min(500, $limit));
+    $st = db()->prepare($sql);
+    $st->execute($params);
+    return $st->fetchAll();
+}
+
+/* ==========================================================================
+   Feature gating (§22) — the ONE place any KYC-gated feature is decided
+   ========================================================================== */
+
+/**
+ * Every gate this catalog defines, with a human label for the admin config UI. Adding a new gate is a
+ * one-line change here — never a scattered `if ($kyc === 'approved')` at the call site.
+ */
+const KYC_FEATURE_GATES = [
+    'credit_purchase'          => 'خرید اعتبار',
+    'dedicated_number_request' => 'درخواست شماره اختصاصی',
+    'production_api'           => 'دسترسی API عملیاتی',
+    'high_volume_send'         => 'ارسال حجم بالا',
+];
+
+/** ellsms_settings key for one gate's on/off switch. */
+function kyc_gate_setting_key(string $gate): string {
+    return 'kyc_gate.' . $gate;
+}
+
+/**
+ * Whether $gate currently REQUIRES an approved KYC (admin-configurable, defaults to false/off for
+ * every gate — §22: "Default migration behavior should preserve the current production behavior. Do
+ * not unexpectedly block current customers.").
+ */
+function kyc_gate_required(string $gate): bool {
+    if (!array_key_exists($gate, KYC_FEATURE_GATES)) {
+        return false;
+    }
+    return setting(kyc_gate_setting_key($gate), '0') === '1';
+}
+
+function kyc_gate_set_required(string $gate, bool $required, int $actorUserId): void {
+    if (!array_key_exists($gate, KYC_FEATURE_GATES)) {
+        return;
+    }
+    set_setting(kyc_gate_setting_key($gate), $required ? '1' : '0');
+    audit($actorUserId, 'kyc.gate_configured', "gate={$gate} required=" . ($required ? '1' : '0'));
+}
+
+/**
+ * The pure decision, isolated from the ellsms_settings lookup on purpose — trivially unit-testable
+ * (tests/Unit/KycWorkflowTest.php) without touching setting()'s process-wide cache, which by design
+ * (see IntegrationTestCase's own docblock on `default_originator`) only ever reflects the FIRST value
+ * read in a process and cannot be exercised for a second value from an integration test.
+ */
+function kyc_feature_allowed_for_status(bool $gateRequired, string $kycStatus): bool {
+    return !$gateRequired || $kycStatus === 'approved';
+}
+
+/**
+ * THE centralized policy function (§22's explicit request) — every call site in this codebase that
+ * needs to know "is $organizationId allowed to use $gate right now" calls this and NOTHING else. It
+ * is intentionally a pure yes/no: a gate that is off always returns true (today's behavior, unchanged
+ * for every existing customer); a gate that is on returns true only for an organization whose KYC
+ * request is 'approved'.
+ *
+ * Not wired into any existing feature's code path by this phase (billing/wallet/numbers stay
+ * untouched per the phase brief's own "do not change... except where explicitly required for
+ * configurable KYC gating" — and no gate defaults to required, so nothing needs to change yet). The
+ * function exists, is tested, and is ready for the day an operator flips a gate on; see
+ * docs/profile-kyc.md §Feature gating for exactly what integrating a real call site looks like.
+ */
+function kyc_feature_allowed(int $organizationId, string $gate): bool {
+    $request = kyc_request_get($organizationId);
+    return kyc_feature_allowed_for_status(kyc_gate_required($gate), (string)($request['status'] ?? 'draft'));
+}

--- a/app/Profile.php
+++ b/app/Profile.php
@@ -30,14 +30,46 @@ declare(strict_types=1);
    Catalogs (STEP 7/15/32)
    ========================================================================== */
 
-/** Company types. `unspecified` is a real, storable value — not every organization is a company. */
-const PROFILE_COMPANY_TYPES = [
-    'legal_entity'        => 'شخص حقوقی',
-    'individual_business' => 'کسب‌وکار انفرادی',
-    'government'          => 'دولتی / عمومی',
-    'other'               => 'سایر',
-    'unspecified'         => 'نامشخص',
+/**
+ * Account type — durable, organization-profile-level (never a scattered per-feature flag). Every
+ * organization has exactly one: حقیقی (individual) or حقوقی (legal). Existing organizations backfill
+ * to 'individual' unless their existing data already looks like a company (db/migrations/
+ * 2026_08_17_kyc_workflow.sql), so no production organization is silently reclassified as legal.
+ */
+const PROFILE_ACCOUNT_TYPES = [
+    'individual' => 'حقیقی',
+    'legal'      => 'حقوقی',
 ];
+
+function profile_account_type_label(string $type): string {
+    return PROFILE_ACCOUNT_TYPES[$type] ?? PROFILE_ACCOUNT_TYPES['individual'];
+}
+
+/**
+ * Company types — ONE centralized catalog (§5 of the KYC phase brief: "Do not hard-code display
+ * labels in multiple places"). The original five values (`legal_entity` … `unspecified`) predate this
+ * phase and are kept exactly as-is for backward compatibility with rows already saved against them;
+ * the Iranian legal-entity types below are ADDITIVE, widened into the same database ENUM by
+ * db/migrations/2026_08_17_kyc_workflow.sql so no existing row's value ever needs rewriting.
+ * `unspecified` remains the default — not every organization is a company.
+ */
+const PROFILE_COMPANY_TYPES = [
+    'legal_entity'         => 'شخص حقوقی',
+    'individual_business'  => 'کسب‌وکار انفرادی',
+    'government'           => 'دولتی / عمومی',
+    'private_joint_stock'  => 'سهامی خاص',
+    'public_joint_stock'   => 'سهامی عام',
+    'limited_liability'    => 'مسئولیت محدود',
+    'cooperative'          => 'تعاونی',
+    'institution'          => 'مؤسسه',
+    'governmental'         => 'دولتی',
+    'other'                => 'سایر',
+    'unspecified'          => 'نامشخص',
+];
+
+function profile_company_type_label(string $type): string {
+    return PROFILE_COMPANY_TYPES[$type] ?? $type;
+}
 
 const PROFILE_GENDERS = [
     'male'        => 'مرد',
@@ -51,17 +83,28 @@ const PROFILE_GENDERS = [
  * the wrong audience.
  */
 const PROFILE_USER_DOCUMENT_TYPES = [
-    'national_card'      => 'کارت ملی',
-    'birth_certificate'  => 'شناسنامه',
+    'national_card'               => 'کارت ملی',
+    'birth_certificate'           => 'شناسنامه',
+    'selfie_with_national_card'   => 'سلفی با کارت ملی',
+    'address_proof'               => 'مدرک آدرس محل سکونت',
 ];
 
 const PROFILE_ORGANIZATION_DOCUMENT_TYPES = [
-    'incorporation_notice'   => 'آگهی تأسیس',
-    'latest_changes_notice'  => 'آگهی آخرین تغییرات',
-    'registration_document'  => 'سند ثبت شرکت',
-    'introduction_letter'    => 'معرفی‌نامه',
-    'postal_certificate'     => 'تأییدیه کد پستی',
+    'incorporation_notice'         => 'آگهی تأسیس',
+    'latest_changes_notice'        => 'آگهی آخرین تغییرات',
+    'registration_document'        => 'سند ثبت شرکت',
+    'introduction_letter'          => 'معرفی‌نامه',
+    'postal_certificate'           => 'تأییدیه کد پستی',
+    'representative_national_card' => 'کارت ملی نماینده قانونی',
 ];
+
+/**
+ * The MINIMUM document set §16 requires before a KYC request may be submitted, by account type.
+ * Deliberately a small, product-defined subset of the full catalogs above — every catalog entry is
+ * always uploadable, but only these are BLOCKING for submission (app/Kyc.php's kyc_can_submit()).
+ */
+const PROFILE_REQUIRED_DOCUMENTS_INDIVIDUAL = ['national_card', 'selfie_with_national_card'];
+const PROFILE_REQUIRED_DOCUMENTS_LEGAL = ['incorporation_notice', 'representative_national_card'];
 
 /**
  * Fields a LEGAL ENTITY is expected to provide, used only by the completeness figure and the
@@ -261,9 +304,11 @@ function profile_user_save(int $userId, array $input, int $actorUserId): array {
 
 function profile_organization_get(int $organizationId): array {
     $empty = [
-        'organization_id' => $organizationId, 'legal_name' => '', 'company_type' => 'unspecified',
+        'organization_id' => $organizationId, 'account_type' => 'individual',
+        'legal_name' => '', 'company_type' => 'unspecified',
         'registration_number' => '', 'national_id' => '', 'economic_code' => '', 'ceo_name' => '',
         'ceo_father_name' => '', 'ceo_national_code' => '', 'ceo_birth_date' => null,
+        'ceo_birth_city' => '', 'ceo_mobile' => '', 'ceo_email' => '',
         'company_start_date' => null, 'company_expiry_date' => null, 'legal_representative_user_id' => null,
     ];
     if ($organizationId <= 0) {
@@ -283,8 +328,30 @@ function profile_organization_save(int $organizationId, array $input, int $actor
     if ($organizationId <= 0) {
         return ['ok' => false, 'reason' => 'invalid_organization'];
     }
+
+    // §13 — "no silent data loss": a caller that supplies only SOME fields (the account_type toggle
+    // on the profile page is exactly this — it deliberately sends nothing else) must never blank out
+    // whatever is already on file. Any key ABSENT from $input falls back to the current row; a key
+    // PRESENT with an empty string is still a real, explicit clear (a form field the user emptied on
+    // purpose). The array union operator does exactly this: left operand wins per-key, right operand
+    // only fills gaps — never overwrites a key $input already set, even to ''.
+    $previous = profile_organization_get($organizationId);
+    $input = $input + $previous;
+
     $companyType = in_array($input['company_type'] ?? '', array_keys(PROFILE_COMPANY_TYPES), true)
         ? $input['company_type'] : 'unspecified';
+
+    // account_type is DURABLE and organization-scoped (§1 of the KYC phase brief) — changing it here
+    // is a metadata switch only; §13's "no silent data loss" rule is enforced by never deleting the
+    // dormant side's rows, never by refusing the switch itself.
+    $accountType = in_array($input['account_type'] ?? '', array_keys(PROFILE_ACCOUNT_TYPES), true)
+        ? $input['account_type'] : ($previous['account_type'] ?? 'individual');
+    $accountTypeChanged = $accountType !== ($previous['account_type'] ?? 'individual');
+
+    $ceoEmailRaw = profile_clean_text((string)($input['ceo_email'] ?? ''), 190);
+    if ($ceoEmailRaw !== '' && !filter_var($ceoEmailRaw, FILTER_VALIDATE_EMAIL)) {
+        return ['ok' => false, 'reason' => 'invalid_ceo_email'];
+    }
 
     $startDate  = $input['company_start_date'] ?? null;
     $expiryDate = $input['company_expiry_date'] ?? null;
@@ -309,20 +376,24 @@ function profile_organization_save(int $organizationId, array $input, int $actor
 
     db()->prepare(
         'INSERT INTO ellsms_organization_profiles
-           (organization_id, legal_name, company_type, registration_number, national_id, economic_code,
-            ceo_name, ceo_father_name, ceo_national_code, ceo_birth_date, company_start_date,
-            company_expiry_date, legal_representative_user_id)
-         VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?)
+           (organization_id, account_type, legal_name, company_type, registration_number, national_id, economic_code,
+            ceo_name, ceo_father_name, ceo_national_code, ceo_birth_date, ceo_birth_city, ceo_mobile, ceo_email,
+            company_start_date, company_expiry_date, legal_representative_user_id)
+         VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)
          ON DUPLICATE KEY UPDATE
+           account_type = VALUES(account_type),
            legal_name = VALUES(legal_name), company_type = VALUES(company_type),
            registration_number = VALUES(registration_number), national_id = VALUES(national_id),
            economic_code = VALUES(economic_code), ceo_name = VALUES(ceo_name),
            ceo_father_name = VALUES(ceo_father_name), ceo_national_code = VALUES(ceo_national_code),
-           ceo_birth_date = VALUES(ceo_birth_date), company_start_date = VALUES(company_start_date),
+           ceo_birth_date = VALUES(ceo_birth_date), ceo_birth_city = VALUES(ceo_birth_city),
+           ceo_mobile = VALUES(ceo_mobile), ceo_email = VALUES(ceo_email),
+           company_start_date = VALUES(company_start_date),
            company_expiry_date = VALUES(company_expiry_date),
            legal_representative_user_id = VALUES(legal_representative_user_id)'
     )->execute([
         $organizationId,
+        $accountType,
         profile_clean_text((string)($input['legal_name'] ?? ''), 190),
         $companyType,
         profile_normalize_digits((string)($input['registration_number'] ?? '')),
@@ -332,13 +403,21 @@ function profile_organization_save(int $organizationId, array $input, int $actor
         profile_clean_text((string)($input['ceo_father_name'] ?? ''), 120),
         $ceoNationalCode,
         $input['ceo_birth_date'] ?? null,
+        profile_clean_text((string)($input['ceo_birth_city'] ?? ''), 60),
+        profile_normalize_digits((string)($input['ceo_mobile'] ?? '')),
+        $ceoEmailRaw,
         $startDate,
         $expiryDate,
         $representativeId > 0 ? $representativeId : null,
     ]);
 
-    audit($actorUserId, 'profile.organization_update', "org={$organizationId} type={$companyType}");
-    Logger::info('profile.organization_updated', ['organization_id' => $organizationId, 'actor_user_id' => $actorUserId]);
+    if ($accountTypeChanged) {
+        // A dedicated event (§19), separate from the generic profile.organization_update line, so an
+        // auditor can find every account-type switch without grepping every field-level change.
+        audit($actorUserId, 'profile.account_type_changed', "org={$organizationId} from={$previous['account_type']} to={$accountType}");
+    }
+    audit($actorUserId, 'profile.updated', "org={$organizationId} type={$companyType} account_type={$accountType}");
+    Logger::info('profile.organization_updated', ['organization_id' => $organizationId, 'actor_user_id' => $actorUserId, 'account_type' => $accountType]);
     return ['ok' => true];
 }
 
@@ -685,6 +764,7 @@ function profile_error_message(string $reason): string {
         'invalid_organization'        => 'سازمان فعالی برای این عملیات وجود ندارد.',
         'invalid_national_code'       => 'کد ملی باید دقیقاً ۱۰ رقم باشد.',
         'invalid_ceo_national_code'   => 'کد ملی مدیرعامل باید دقیقاً ۱۰ رقم باشد.',
+        'invalid_ceo_email'           => 'ایمیل نماینده معتبر نیست.',
         'invalid_postal_code'         => 'کد پستی باید دقیقاً ۱۰ رقم باشد.',
         'invalid_threshold'           => 'آستانه‌ی اعتبار نامعتبر است.',
         'invalid_email'               => 'ایمیل اعلان معتبر نیست.',
@@ -741,5 +821,36 @@ function profile_organization_completeness(array $profile, array $address): arra
         $missing[] = 'شهر';
     }
     $total = count($required) + 2;
+    return ['percent' => (int)round((($total - count($missing)) / $total) * 100), 'missing' => $missing];
+}
+
+/**
+ * The single, centralized profile-completion figure shown at the top of the profile page (§14 of the
+ * KYC phase brief) — "تکمیل پروفایل: NN٪". Deterministic and testable: which underlying score it
+ * reports depends only on account_type, never on which fields happen to be filled in.
+ *
+ * individual -> personal identity fields (profile_user_completeness) plus the organization's address,
+ * since §3's individual field set explicitly includes address/contact information.
+ * legal -> the existing company completeness score, which already folds the address in.
+ *
+ * Optional fields (landline, fax, customer_code, alley/plaque beyond what's already scored) are
+ * deliberately NOT counted — §3/§4's "do not unnecessarily require optional fields."
+ *
+ * @return array{percent:int, missing:list<string>}
+ */
+function profile_account_completeness(string $accountType, array $userProfile, array $organizationProfile, array $address): array {
+    if ($accountType === 'legal') {
+        return profile_organization_completeness($organizationProfile, $address);
+    }
+
+    $personal = profile_user_completeness($userProfile);
+    $addressLabels = ['postal_code' => 'کد پستی', 'city' => 'شهر'];
+    $missing = $personal['missing'];
+    foreach ($addressLabels as $field => $label) {
+        if (($address[$field] ?? '') === '') {
+            $missing[] = $label;
+        }
+    }
+    $total = 4 /* profile_user_completeness's own field count */ + count($addressLabels);
     return ['percent' => (int)round((($total - count($missing)) / $total) * 100), 'missing' => $missing];
 }

--- a/app/bootstrap.php
+++ b/app/bootstrap.php
@@ -76,6 +76,10 @@ require_once __DIR__ . '/Reports/MessageDetail.php';
 // preferences and private documents (docs/customer-profile.md). Loaded last: it composes tenant.php
 // (organization membership), rbac.php (settings.manage) and audit(), and owns none of them.
 require_once __DIR__ . '/Profile.php';
+// KYC review workflow — state machine, per-document review, submission eligibility, feature gating
+// (docs/profile-kyc.md). Composes Profile.php (document storage/catalogs) and audit(); owns neither.
+require_once __DIR__ . '/Kyc.php';
+require_once __DIR__ . '/AllowedIps.php';
 
 /* ---------- Environment ---------- */
 function env(string $key, ?string $default = null): ?string {

--- a/app/views/header.php
+++ b/app/views/header.php
@@ -37,6 +37,7 @@ if ($navOrg && membership_has_permission($navOrg, Permissions::BILLING_VIEW)) {
 }
 $adminNav = [
     'users'             => ['/users.php',             'کاربران',        '👤'],
+    'kyc_review'        => ['/kyc-review.php',        'بررسی احراز هویت', '🪪'],
     'analytics'         => ['/analytics.php',          'آمار تفصیلی',    '📊'],
     'numbers'           => ['/numbers.php',            'شماره‌ها',        '📞'],
     'number_categories' => ['/number-categories.php',  'دسته‌های شماره',  '🗂'],

--- a/db/migrations/2026_08_17_kyc_workflow.sql
+++ b/db/migrations/2026_08_17_kyc_workflow.sql
@@ -1,0 +1,157 @@
+-- KYC review workflow — durable account type, KYC request state machine, per-document review,
+-- allowed-IP management (docs/profile-kyc.md).
+--
+-- This continues docs/customer-profile.md's §11 "Limitations — No KYC approval workflow" note:
+-- that phase deliberately stored/replaced/archived documents without reviewing or approving them.
+-- This migration adds exactly the missing piece — nothing here touches a backend-owned table
+-- (user_/domain/outbound_message/inbound_message), and nothing existing is dropped, renamed or
+-- rewritten. `ellsms_profile_documents` and `ellsms_organization_profiles` gain ADDITIVE columns
+-- only; every existing row keeps every value it already has.
+--
+-- ACCOUNT TYPE lives on `ellsms_organization_profiles` (organization_id primary key) — the account/
+-- tenant boundary — never scattered onto `ellsms_organizations` or `ellsms_meta` as an unrelated
+-- flag. This matches the existing ownership rule in docs/customer-profile.md: company/legal-shaped
+-- data belongs to the organization, not to an individual user row.
+--
+-- BACKFILL SAFETY: every existing organization gets `account_type = 'individual'` UNLESS it already
+-- has legal/company data on file (a non-'unspecified' company_type or a non-empty legal_name), in
+-- which case it backfills to 'legal'. No organization is forced into an incomplete KYC flow by this
+-- migration — `ellsms_kyc_requests` rows are created lazily, on first read (app/Kyc.php), so an
+-- organization that never touches KYC never gets a row at all and is completely unaffected.
+--
+-- NO GENERATED COLUMNS (TD-070) — see db/migrations/2026_08_12_customer_profile.sql's own note; the
+-- same restore-safety reasoning applies to every table below.
+SET NAMES utf8mb4;
+
+-- 0) Widen company_type to the controlled Iranian legal-entity set (§5 of the KYC phase brief),
+-- ADDITIVELY: every value this ENUM already accepted stays valid, so no existing row is rewritten or
+-- coerced. app/Profile.php's PROFILE_COMPANY_TYPES is the single source of truth for the full list.
+SET @needs_type = (
+  SELECT COUNT(*) = 0 FROM information_schema.columns
+  WHERE table_schema = DATABASE() AND table_name = 'ellsms_organization_profiles'
+    AND column_name = 'company_type' AND column_type LIKE '%private_joint_stock%'
+);
+SET @sql = IF(@needs_type = 1,
+  "ALTER TABLE ellsms_organization_profiles
+     MODIFY COLUMN company_type ENUM(
+       'legal_entity','individual_business','government',
+       'private_joint_stock','public_joint_stock','limited_liability','cooperative','institution','governmental',
+       'other','unspecified'
+     ) NOT NULL DEFAULT 'unspecified'",
+  'SELECT 1'
+);
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+-- 1) Durable account type on the organization profile.
+SET @col_exists = (
+  SELECT COUNT(*) FROM information_schema.columns
+  WHERE table_schema = DATABASE() AND table_name = 'ellsms_organization_profiles'
+    AND column_name = 'account_type'
+);
+SET @sql = IF(@col_exists = 0,
+  "ALTER TABLE ellsms_organization_profiles
+     ADD COLUMN account_type ENUM('individual','legal') NOT NULL DEFAULT 'individual' AFTER organization_id",
+  'SELECT 1'
+);
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+SET @idx_exists = (
+  SELECT COUNT(*) FROM information_schema.statistics
+  WHERE table_schema = DATABASE() AND table_name = 'ellsms_organization_profiles' AND index_name = 'idx_account_type'
+);
+SET @sql = IF(@idx_exists = 0,
+  'ALTER TABLE ellsms_organization_profiles ADD INDEX idx_account_type (account_type)',
+  'SELECT 1'
+);
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+-- Representative contact fields, additive to the existing `ceo_*` columns (docs/customer-profile.md's
+-- ceo_name/ceo_father_name/ceo_national_code/ceo_birth_date already model the legal representative —
+-- these three close the gap against §4's requested field set without inventing a second, parallel
+-- `representative_*` naming scheme for the same person).
+SET @col_exists = (
+  SELECT COUNT(*) FROM information_schema.columns
+  WHERE table_schema = DATABASE() AND table_name = 'ellsms_organization_profiles' AND column_name = 'ceo_birth_city'
+);
+SET @sql = IF(@col_exists = 0,
+  "ALTER TABLE ellsms_organization_profiles
+     ADD COLUMN ceo_birth_city VARCHAR(60) NOT NULL DEFAULT '' AFTER ceo_birth_date,
+     ADD COLUMN ceo_mobile VARCHAR(20) NOT NULL DEFAULT '' AFTER ceo_birth_city,
+     ADD COLUMN ceo_email VARCHAR(190) NOT NULL DEFAULT '' AFTER ceo_mobile",
+  'SELECT 1'
+);
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+-- Safe backfill: only touches rows that already exist (nothing forces a *new* row into existence),
+-- and only sets account_type = 'legal' where the existing data already looks like a company. Every
+-- other organization keeps the safe 'individual' default a bare INSERT already gave it above.
+UPDATE ellsms_organization_profiles
+   SET account_type = 'legal'
+ WHERE account_type = 'individual'
+   AND (company_type <> 'unspecified' OR legal_name <> '');
+
+-- 2) Per-document review state — additive columns on the existing documents table. Every existing
+-- document row (all of them uploaded before a review workflow existed) backfills to 'pending', which
+-- is correct: nothing has been reviewed yet, and 'pending' is not "rejected."
+SET @col_exists = (
+  SELECT COUNT(*) FROM information_schema.columns
+  WHERE table_schema = DATABASE() AND table_name = 'ellsms_profile_documents' AND column_name = 'review_status'
+);
+SET @sql = IF(@col_exists = 0,
+  "ALTER TABLE ellsms_profile_documents
+     ADD COLUMN review_status ENUM('pending','approved','rejected') NOT NULL DEFAULT 'pending' AFTER status,
+     ADD COLUMN reviewed_at TIMESTAMP NULL AFTER review_status,
+     ADD COLUMN reviewed_by_user_id BIGINT NULL AFTER reviewed_at,
+     ADD COLUMN review_note VARCHAR(500) NOT NULL DEFAULT '' AFTER reviewed_by_user_id",
+  'SELECT 1'
+);
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+SET @idx_exists = (
+  SELECT COUNT(*) FROM information_schema.statistics
+  WHERE table_schema = DATABASE() AND table_name = 'ellsms_profile_documents' AND index_name = 'idx_review_status'
+);
+SET @sql = IF(@idx_exists = 0,
+  'ALTER TABLE ellsms_profile_documents ADD INDEX idx_review_status (review_status)',
+  'SELECT 1'
+);
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+-- 3) The KYC request — ONE row per organization (the account/tenant boundary), the same "one row,
+-- lazily created" shape as ellsms_organization_notification_preferences. A row is created only when
+-- an organization actually touches the KYC flow (app/Kyc.php's kyc_request_get()); an organization
+-- that never does has NO row here and is not affected by this migration in any way — this is what
+-- makes the migration safe for existing production customers (STEP 22's "do not unexpectedly block
+-- current customers").
+CREATE TABLE IF NOT EXISTS ellsms_kyc_requests (
+  organization_id     INT UNSIGNED NOT NULL PRIMARY KEY,
+  status               ENUM('draft','submitted','under_review','needs_correction','approved','rejected')
+                          NOT NULL DEFAULT 'draft',
+  submitted_at         TIMESTAMP NULL,
+  review_started_at    TIMESTAMP NULL,
+  reviewed_at          TIMESTAMP NULL,
+  reviewed_by_user_id  BIGINT NULL,          -- = user_.id; no FK, same policy as every other ellsms_* -> user_ reference
+  review_note          VARCHAR(1000) NOT NULL DEFAULT '',
+  created_at           TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  updated_at           TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  KEY idx_kyc_status (status),
+  KEY idx_kyc_submitted (submitted_at),
+  CONSTRAINT fk_kyc_request_org FOREIGN KEY (organization_id) REFERENCES ellsms_organizations(id) ON DELETE RESTRICT
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+-- 4) Allowed-IP management (§20 of the phase brief). MANAGEMENT ONLY — see docs/profile-kyc.md for
+-- exactly which enforcement hook (if any) reads this table today. Multiple entries per organization,
+-- each independently enable/disable-able so a mistake never requires deleting history.
+CREATE TABLE IF NOT EXISTS ellsms_organization_allowed_ips (
+  id                 BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+  organization_id    INT UNSIGNED NOT NULL,
+  ip_or_cidr         VARCHAR(64) NOT NULL,   -- validated IPv4/IPv6, optionally with a /prefix, before insert
+  label              VARCHAR(120) NOT NULL DEFAULT '',
+  status             ENUM('active','disabled') NOT NULL DEFAULT 'active',
+  created_by_user_id BIGINT NULL,
+  created_at         TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  updated_at         TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  UNIQUE KEY uniq_org_ip (organization_id, ip_or_cidr),
+  KEY idx_org_status (organization_id, status),
+  CONSTRAINT fk_allowed_ip_org FOREIGN KEY (organization_id) REFERENCES ellsms_organizations(id) ON DELETE RESTRICT
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;

--- a/docs/profile-kyc.md
+++ b/docs/profile-kyc.md
@@ -1,0 +1,258 @@
+# Profile + KYC management
+
+Account type (حقیقی/حقوقی), the KYC review workflow, per-document review, admin review UI, allowed-IP
+management, and configurable KYC feature gating.
+
+Code: `app/Kyc.php` (workflow), `app/Profile.php` (extended), `app/AllowedIps.php` · Pages:
+`public/profile.php` (self-service), `public/kyc-review.php` (platform admin) · Schema:
+`db/migrations/2026_08_17_kyc_workflow.sql`
+
+This continues `docs/customer-profile.md`, which deliberately shipped without a review workflow
+(§11: "No KYC approval workflow — documents are stored, replaced and archived; nothing reviews or
+approves them"). Read that document first — it owns the underlying data model (personal profile,
+company profile, address, documents) that this phase builds a workflow on top of, without changing
+it.
+
+---
+
+## 1. Account type
+
+Every organization has exactly one durable `account_type`, stored on `ellsms_organization_profiles`
+(the organization/account profile level, never scattered as a per-feature flag):
+
+| Value | Persian label |
+|---|---|
+| `individual` | حقیقی |
+| `legal` | حقوقی |
+
+**Migration safety.** Every existing organization backfills to `individual` unless its existing data
+already looks like a company (a non-`unspecified` `company_type` or a non-empty `legal_name`), in
+which case it backfills to `legal`. No organization is forced into an incomplete KYC flow by the
+migration — a KYC request row is created lazily, on first read, so an organization that never touches
+KYC has no row and is completely unaffected.
+
+**Switching is non-destructive.** `profile_organization_save()` merges its input against the current
+row before writing (any field not explicitly present in the caller's input falls back to what is
+already stored), so toggling `account_type` alone — which is exactly what the profile page's "نوع
+حساب" control does — can never blank out company data, representative data, or documents. Both
+sides' data and documents simply stay stored; only which UI sections are shown, and which document
+set is required for submission, changes. A field explicitly submitted as empty is still a real,
+deliberate clear — this only protects against fields the caller never mentioned.
+
+## 2. Field ownership
+
+Unchanged from `docs/customer-profile.md` §1/§2, extended additively:
+
+| Field | Table | Notes |
+|---|---|---|
+| `account_type` | `ellsms_organization_profiles` | new |
+| Representative contact (`ceo_birth_city`, `ceo_mobile`, `ceo_email`) | `ellsms_organization_profiles` | new — additive to the existing `ceo_name`/`ceo_father_name`/`ceo_national_code`/`ceo_birth_date`, which already modeled the legal representative. No second, parallel `representative_*` naming scheme was introduced for the same person. |
+| `company_type` | `ellsms_organization_profiles` | ENUM widened additively with the Iranian legal-entity types (`private_joint_stock`, `public_joint_stock`, `limited_liability`, `cooperative`, `institution`, `governmental`), the original 5 values kept for backward compatibility |
+| KYC request state | `ellsms_kyc_requests` | new, one row per organization |
+| Document review state | `ellsms_profile_documents.review_status`/`reviewed_at`/`reviewed_by_user_id`/`review_note` | new, additive columns |
+| Allowed IPs | `ellsms_organization_allowed_ips` | new |
+
+`app/Kyc.php` never writes to `user_`, matching Profile.php's own boundary rule.
+
+## 3. Document catalog
+
+Additive to `docs/customer-profile.md`'s catalog:
+
+| User | Organization |
+|---|---|
+| `national_card`, `birth_certificate`, `selfie_with_national_card`, `address_proof` | `incorporation_notice`, `latest_changes_notice`, `registration_document`, `introduction_letter`, `postal_certificate`, `representative_national_card` |
+
+**Minimum required for submission** (`PROFILE_REQUIRED_DOCUMENTS_INDIVIDUAL` /
+`_LEGAL` in `app/Profile.php`), a deliberately small, product-defined subset of the full catalog:
+
+- individual: `national_card`, `selfie_with_national_card`
+- legal: `incorporation_notice`, `representative_national_card`
+
+Every catalog entry is always uploadable; only these are *blocking* for submission.
+
+## 4. KYC state machine
+
+```
+draft -> submitted
+submitted -> under_review
+under_review -> approved | needs_correction | rejected
+needs_correction -> submitted
+rejected -> submitted
+approved -> (terminal)
+```
+
+`KYC_TRANSITIONS` (`app/Kyc.php`) is the *only* table of allowed transitions, and `kyc_transition()`
+is the *only* function that writes `ellsms_kyc_requests.status` — every write locks the row
+(`SELECT ... FOR UPDATE`), re-checks the transition against the table, and refuses (`invalid_transition`)
+anything not explicitly listed. `submitted_at`, `review_started_at`, `reviewed_at`,
+`reviewed_by_user_id` and `review_note` are set by the same function, keyed off which transition ran,
+never by a separate write path.
+
+**Submission eligibility** (`kyc_can_submit()` / `kyc_submit()`) is centralized and shared —
+`public/profile.php` calls the exact same function `public/kyc-review.php` would use to sanity-check,
+so there is no separate, potentially-drifting "the UI thinks this is complete" rule. A user may not
+submit unless their account type's minimum profile fields, address, and required documents are all
+present.
+
+## 5. Document review
+
+Independent of the overall KYC request status. Each document carries its own
+`pending` / `approved` / `rejected` review state, settable only by a platform admin
+(`kyc_document_review()`, called from `public/kyc-review.php`). Replacing a document (uploading a new
+one of the same type) archives the old row *and* starts the new one at `pending` — a rejection never
+survives onto a replacement upload (`ellsms_profile_documents.review_status` is a plain column on
+each row, not carried through `profile_document_archive_active()`).
+
+## 6. Admin review flow
+
+`public/kyc-review.php` — platform-admin-only:
+
+- **List** (`kyc_requests_list()`): filter by status, search by organization/legal name or numeric
+  organization id.
+- **Detail** (`?id=<organization_id>`): profile data (branch by `account_type`), every document with
+  its review state, the request's own timestamps, and the set of transitions currently legal from
+  `KYC_TRANSITIONS`.
+- **Actions**: transition the overall request (with an optional review note, required in practice for
+  `needs_correction`/`rejected`); approve/reject an individual document with its own note.
+- Every document link routes through the existing `public/profile-document.php` — nothing here
+  renders a document inline or exposes a second, unauthenticated path to one.
+- A document review POST re-validates that the document actually belongs to the organization (or its
+  owning user) the screen is scoped to before accepting the action — a cross-organization
+  `document_id` is refused, matching `profile_document_belongs_to()`'s existing ownership check.
+
+## 7. RBAC
+
+`Permissions::KYC_VIEW` / `KYC_MANAGE` stay exactly as `app/rbac.php` already documents: **reserved**,
+granted to no organization role by default, not even owner. This phase does not reopen that decision.
+Every admin-facing KYC action lives on `public/kyc-review.php` and is gated by `require_admin()`, the
+same platform-admin-only model the pre-existing `public/users.php` KYC fields and
+`public/kyc-photo.php` already use. Broadening identity-document review to an organization role
+"merely because RBAC exists" is exactly what `docs/customer-profile.md` §3 already warned against, and
+this phase agrees with that reasoning rather than relitigating it.
+
+Self-service actions on `public/profile.php` (submitting a KYC request, uploading a document,
+managing allowed IPs) use the existing `settings.manage` permission for anything organization-scoped,
+identical to the rest of that page.
+
+## 8. Audit
+
+Every action in the phase brief's list is audited via the existing `audit()` (`app/bootstrap.php`):
+`profile.account_type_changed`, `profile.updated`, `kyc.document_uploaded` (already
+`profile.document_upload` from Phase — see note below), `kyc.document_approved`,
+`kyc.document_rejected`, `kyc.submitted`, `kyc.review_started`, `kyc.approved`,
+`kyc.needs_correction`, `kyc.rejected`, `allowed_ip.created`, `allowed_ip.deleted`.
+
+Document *upload* itself keeps `docs/customer-profile.md`'s original audit action name
+(`profile.document_upload`) rather than introducing a second, differently-named event for the same
+write — grepping the audit log for either name finds the same rows. Review notes are **never** written
+into the audit trail (only that a review happened, and by whom) — a review note can legitimately
+reference sensitive specifics ("national code photo is blurry"), matching
+`profile_mask_identifier()`'s existing precedent of never duplicating sensitive text into the trail.
+
+## 9. Feature gating
+
+`kyc_feature_allowed(int $organizationId, string $gate): bool` (`app/Kyc.php`) is the **one** place any
+KYC-gated feature is decided. Catalog (`KYC_FEATURE_GATES`): `credit_purchase`,
+`dedicated_number_request`, `production_api`, `high_volume_send`.
+
+Each gate's on/off switch is an ordinary `ellsms_settings` row (`kyc_gate.<gate>`, via the existing
+`setting()`/`set_setting()`), **defaulting to off** — §22's explicit "default migration behavior must
+preserve current production behavior; do not unexpectedly block current customers." An operator turns
+a gate on with `kyc_gate_set_required()`; nothing in this phase turns one on automatically.
+
+**Not wired into any existing feature's code path.** Billing, wallet, and numbers are explicitly out
+of scope for this phase except for the gating *mechanism* itself — no gate defaults to required, so no
+existing call site needs to change today. Integrating a real feature means, at that feature's own
+entry point: `if (!kyc_feature_allowed($organizationId, 'credit_purchase')) { …refuse with a clear
+Persian message… }` — one line, never a bare `if ($kyc === 'approved')` scattered through unrelated
+files.
+
+The yes/no decision itself (`kyc_feature_allowed_for_status()`) is a pure function, separated from the
+`ellsms_settings` lookup specifically so it is unit-testable without the settings cache's known
+process-lifetime caching behavior (see `tests/Integration/IntegrationTestCase.php`'s own note on
+`default_originator` — the same limitation applies to any `ellsms_settings`-backed value read more
+than once per process).
+
+## 10. Allowed IP management
+
+`app/AllowedIps.php` + `ellsms_organization_allowed_ips`. Validates IPv4, IPv6, and CIDR
+(`allowed_ip_normalize()`), normalizes Persian/Arabic digits first, enforces uniqueness per
+organization, and audits create/delete.
+
+**Enforcement status: NOT implemented.** This is management only. ELLSMS's login and API-key paths
+(`app/authorization.php`, `app/rate_limit.php`) have no existing "check the caller's IP against a
+per-organization allowlist" hook, and the phase brief is explicit that enforcement is added only "if
+the project already has a clear safe hook" — wiring one in blind risks locking an administrator out
+mid-migration, which the brief explicitly forbids. An organization can record and manage its expected
+IPs today; nothing currently refuses a request based on them. Building real enforcement is future work
+and would need its own design (which paths it applies to, what happens to an admin locked out by their
+own configuration, whether platform-admin/impersonation is exempt) — deliberately not invented here.
+
+## 11. Low-credit preferences
+
+Unchanged from `docs/customer-profile.md` §11: `ellsms_organization_notification_preferences` already
+stores `low_credit_alert_enabled`/`low_credit_threshold`/`email_alert_enabled`/`sms_alert_enabled` in
+the wallet's own CREDIT unit. This phase does not touch that table or invent a second one — see that
+document for the (unchanged) statement that the preference is stored, not automatically sent.
+
+## 12. Profile completion
+
+`profile_account_completeness()` (`app/Profile.php`) is the single, centralized, deterministic
+completion figure shown on the profile page — which underlying score it reports depends only on
+`account_type`:
+
+- `individual`: personal identity fields (`profile_user_completeness()`) plus address city/postal
+  code.
+- `legal`: the existing company completeness score (`profile_organization_completeness()`), which
+  already folds the address in.
+
+Optional fields are never counted as completion blockers, matching
+`docs/customer-profile.md`'s existing "half-filled and saveable" philosophy.
+
+## 13. Tenant isolation
+
+Every new query is organization-scoped or ownership-checked, following the exact patterns
+`docs/customer-profile.md` already established:
+
+- `ellsms_kyc_requests` is keyed by `organization_id`; `kyc_transition()`/`kyc_request_get()` never
+  accept a bare id without it being the caller's own resolved organization.
+- Document review (`kyc_document_review()`) operates on a document row already resolved by id;
+  `public/kyc-review.php` additionally re-checks `profile_document_belongs_to()` against the
+  organization the admin screen is scoped to before accepting a review action.
+- `ellsms_organization_allowed_ips` operations always take `(organizationId, id)` together — deleting
+  or toggling an id that belongs to a *different* organization is a no-op (`not_found`), never a
+  cross-tenant mutation.
+- Covered directly by `tests/Integration/KycWorkflowIntegrationTest.php` (a transition/account-type
+  change on one organization never affects another; an allowed IP cannot be deleted through a
+  different organization's scope; a document's ownership check is exercised against both the
+  correct and the wrong organization id).
+
+## 14. Migration / backfill
+
+`db/migrations/2026_08_17_kyc_workflow.sql` — additive only, idempotent (same guarded-ALTER pattern as
+every migration since `2026_08_13`): widens `company_type`, adds `account_type` (+ backfill), adds
+representative contact columns, adds document review columns (existing documents backfill to
+`pending` — correct, since none of them have actually been reviewed), creates
+`ellsms_kyc_requests` and `ellsms_organization_allowed_ips`. Nothing existing is dropped, renamed, or
+rewritten. Apply with the existing `make db-migrations-apply` — no new operator command was
+introduced, unlike Phase 12's profile backfill, because there is no legacy data to migrate here.
+
+## 15. API
+
+No new public API surface. `/api/v1/*` endpoints are untouched by this phase — the brief's own
+guidance ("do not expose national ID, document storage keys, document contents, reviewer-only notes")
+is satisfied by not adding any of this to the API at all rather than adding it and then filtering it.
+
+## 16. Known limitations / follow-up
+
+- **Allowed-IP enforcement is not implemented** (§10) — management only, by design, until a safe
+  enforcement hook exists.
+- **No feature gate defaults to required** — the mechanism exists and is tested; turning one on for a
+  specific product feature (credit purchase, dedicated numbers, …) is a follow-up integration at that
+  feature's own call site, deliberately not done here to avoid touching pricing/wallet/billing
+  behavior outside what this phase asked for.
+- **No automatic KYC-status notification** (email/SMS on approval/rejection) — out of scope, same as
+  the pre-existing low-credit-alert sender.
+- **`ellsms_settings`-backed gate toggles are cached per-process** (see §9) — correct across real web
+  requests (one process each), a known limitation only inside a single long-lived PHPUnit process,
+  documented rather than worked around.

--- a/public/kyc-review.php
+++ b/public/kyc-review.php
@@ -1,0 +1,219 @@
+<?php
+/**
+ * ELLSMS — platform-admin KYC review panel (docs/profile-kyc.md §Admin review flow).
+ *
+ * PLATFORM-ADMIN-ONLY, same as every other identity-adjacent admin surface in this codebase
+ * (public/users.php's kyc_save, public/kyc-photo.php) — require_admin() at the top, never delegated
+ * to an organization role. Permissions::KYC_VIEW/KYC_MANAGE stay reserved (app/rbac.php), so this is
+ * not a gap: it is the documented, existing model, continued.
+ *
+ * Documents are never rendered inline here — every preview/download goes through the existing
+ * authorizing endpoint, public/profile-document.php, which already grants a platform admin (outside
+ * impersonation) access to any document.
+ */
+require_once __DIR__ . '/../app/bootstrap.php';
+$me = require_admin();
+$pageTitle = 'بررسی احراز هویت (KYC)';
+$active = 'kyc_review';
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    csrf_check();
+    $do = $_POST['do'] ?? '';
+    $organizationId = (int)($_POST['organization_id'] ?? 0);
+
+    if ($do === 'transition') {
+        $toStatus = (string)($_POST['to_status'] ?? '');
+        $note = (string)($_POST['review_note'] ?? '');
+        $result = kyc_transition($organizationId, $toStatus, (int)$me['id'], $note);
+        flash($result['ok'] ? 'success' : 'error', $result['ok'] ? 'وضعیت درخواست به‌روزرسانی شد.' : 'این تغییر وضعیت مجاز نیست.');
+    } elseif ($do === 'document_review') {
+        $documentId = (int)($_POST['document_id'] ?? 0);
+        $reviewStatus = (string)($_POST['review_status'] ?? '');
+        $note = (string)($_POST['review_note'] ?? '');
+        // Cross-tenant guard: the document must actually belong to the organization this admin
+        // screen is currently open on, so a crafted document_id from a DIFFERENT organization's
+        // review page cannot be replayed here.
+        $document = profile_document_find($documentId);
+        $belongsToOrg = $document !== null && profile_document_belongs_to($document, 'organization', $organizationId);
+        $belongsToOwner = $document !== null && profile_document_belongs_to($document, 'user', (int)($_POST['owner_user_id'] ?? 0));
+        if ($document === null || (!$belongsToOrg && !$belongsToOwner)) {
+            flash('error', 'مدرک یافت نشد.');
+        } else {
+            $result = kyc_document_review($documentId, $reviewStatus, (int)$me['id'], $note);
+            flash($result['ok'] ? 'success' : 'error', $result['ok'] ? 'وضعیت مدرک به‌روزرسانی شد.' : 'ثبت وضعیت ممکن نشد.');
+        }
+    }
+    redirect('/kyc-review.php' . ($organizationId > 0 ? '?id=' . $organizationId : ''));
+}
+
+$detailId = (int)($_GET['id'] ?? 0);
+
+require __DIR__ . '/../app/views/header.php';
+
+if ($detailId > 0):
+    $orgProfile = profile_organization_get($detailId);
+    $orgRow = db()->prepare('SELECT * FROM ellsms_organizations WHERE id = ?');
+    $orgRow->execute([$detailId]);
+    $organization = $orgRow->fetch();
+    if (!$organization):
+        echo '<div class="card"><p class="empty">سازمان یافت نشد.</p></div>';
+    else:
+        $address = profile_address_get($detailId);
+        $kycRequest = kyc_request_get($detailId);
+        $organizationDocuments = profile_documents_list(['organization' => $detailId]);
+        // The individual-account owner's documents live under the organization's OWNER user, so the
+        // reviewer can see personal identity documents for an individual-account organization too.
+        $ownerRow = db()->prepare("SELECT user_id FROM ellsms_organization_memberships WHERE organization_id = ? AND role = 'owner' AND status = 'active' LIMIT 1");
+        $ownerRow->execute([$detailId]);
+        $ownerUserId = (int)($ownerRow->fetchColumn() ?: 0);
+        $ownerProfile = $ownerUserId > 0 ? profile_user_get($ownerUserId) : [];
+        $ownerDocuments = $ownerUserId > 0 ? profile_documents_list(['user' => $ownerUserId]) : [];
+        $accountType = $orgProfile['account_type'] ?? 'individual';
+        $reviewBadgeClass = ['pending' => 'badge-pending', 'approved' => 'badge-ok', 'rejected' => 'badge-off'];
+        ?>
+        <p><a href="/kyc-review.php">&rarr; بازگشت به فهرست</a></p>
+        <div class="card">
+          <h2><?= e((string)$organization['name']) ?>
+            <span class="badge <?= e(['draft'=>'badge-off','rejected'=>'badge-off','submitted'=>'badge-pending','under_review'=>'badge-pending','needs_correction'=>'badge-pending','approved'=>'badge-ok'][$kycRequest['status']] ?? 'badge-off') ?>" style="margin-inline-start:8px">
+              <?= e(kyc_status_label((string)$kycRequest['status'])) ?>
+            </span>
+          </h2>
+          <div class="table-wrap">
+          <table>
+            <tr><th>نوع حساب</th><td><?= e(profile_account_type_label($accountType)) ?></td></tr>
+            <tr><th>نام حقوقی</th><td><?= e((string)$orgProfile['legal_name']) ?: '—' ?></td></tr>
+            <tr><th>ارسال درخواست</th><td><?= $kycRequest['submitted_at'] ? e(jdate((string)$kycRequest['submitted_at'])) : '—' ?></td></tr>
+            <tr><th>شروع بررسی</th><td><?= $kycRequest['review_started_at'] ? e(jdate((string)$kycRequest['review_started_at'])) : '—' ?></td></tr>
+            <tr><th>پایان بررسی</th><td><?= $kycRequest['reviewed_at'] ? e(jdate((string)$kycRequest['reviewed_at'])) : '—' ?></td></tr>
+            <tr><th>یادداشت بازبین</th><td><?= e((string)$kycRequest['review_note']) ?: '—' ?></td></tr>
+          </table>
+          </div>
+
+          <?php $nextStates = KYC_TRANSITIONS[$kycRequest['status']] ?? []; ?>
+          <?php if ($nextStates): ?>
+          <form method="post" style="margin-top:12px">
+            <?= csrf_field() ?>
+            <input type="hidden" name="do" value="transition">
+            <input type="hidden" name="organization_id" value="<?= (int)$detailId ?>">
+            <div class="grid grid-2">
+              <label>وضعیت جدید
+                <select name="to_status">
+                  <?php foreach ($nextStates as $status): ?>
+                    <option value="<?= e($status) ?>"><?= e(kyc_status_label($status)) ?></option>
+                  <?php endforeach; ?>
+                </select>
+              </label>
+              <label>یادداشت بازبینی (در صورت رد یا نیاز به اصلاح) <input type="text" name="review_note" maxlength="1000"></label>
+            </div>
+            <button class="btn btn-primary btn-sm">ثبت تغییر وضعیت</button>
+          </form>
+          <?php else: ?>
+            <p class="hint">این درخواست در وضعیت نهایی است و تغییر بیشتری مجاز نیست.</p>
+          <?php endif; ?>
+        </div>
+
+        <div class="card">
+          <h2>اطلاعات پروفایل</h2>
+          <?php if ($accountType === 'legal'): ?>
+            <div class="table-wrap"><table>
+              <tr><th>مدیرعامل/نماینده</th><td><?= e((string)$orgProfile['ceo_name']) ?: '—' ?></td></tr>
+              <tr><th>کد ملی نماینده</th><td class="ltr"><?= e((string)$orgProfile['ceo_national_code']) ?: '—' ?></td></tr>
+              <tr><th>موبایل نماینده</th><td class="ltr"><?= e((string)$orgProfile['ceo_mobile']) ?: '—' ?></td></tr>
+              <tr><th>شناسه ملی شرکت</th><td class="ltr"><?= e((string)$orgProfile['national_id']) ?: '—' ?></td></tr>
+              <tr><th>شماره ثبت</th><td class="ltr"><?= e((string)$orgProfile['registration_number']) ?: '—' ?></td></tr>
+              <tr><th>آدرس</th><td><?= e(trim((string)$address['province'] . ' ' . (string)$address['city'] . ' ' . (string)$address['street'])) ?: '—' ?></td></tr>
+              <tr><th>کد پستی</th><td class="ltr"><?= e((string)$address['postal_code']) ?: '—' ?></td></tr>
+            </table></div>
+          <?php else: ?>
+            <div class="table-wrap"><table>
+              <tr><th>نام پدر</th><td><?= e((string)($ownerProfile['father_name'] ?? '')) ?: '—' ?></td></tr>
+              <tr><th>کد ملی</th><td class="ltr"><?= e((string)($ownerProfile['national_code'] ?? '')) ?: '—' ?></td></tr>
+              <tr><th>شماره شناسنامه</th><td class="ltr"><?= e((string)($ownerProfile['birth_certificate_no'] ?? '')) ?: '—' ?></td></tr>
+              <tr><th>آدرس</th><td><?= e(trim((string)$address['province'] . ' ' . (string)$address['city'] . ' ' . (string)$address['street'])) ?: '—' ?></td></tr>
+              <tr><th>کد پستی</th><td class="ltr"><?= e((string)$address['postal_code']) ?: '—' ?></td></tr>
+            </table></div>
+          <?php endif; ?>
+        </div>
+
+        <?php
+        $docSections = [
+            ['title' => 'مدارک سازمان', 'documents' => $organizationDocuments, 'owner_user_id' => 0],
+            ['title' => 'مدارک فردی', 'documents' => $ownerDocuments, 'owner_user_id' => $ownerUserId],
+        ];
+        foreach ($docSections as $section):
+            if (!$section['documents']) continue;
+        ?>
+        <div class="card">
+          <h2><?= e($section['title']) ?></h2>
+          <div class="table-wrap">
+          <table>
+            <tr><th>نوع مدرک</th><th>وضعیت فایل</th><th>بررسی</th><th>تاریخ بارگذاری</th><th></th></tr>
+            <?php foreach ($section['documents'] as $document): ?>
+              <tr>
+                <td><?= e(profile_document_type_label((string)$document['document_type'])) ?></td>
+                <td><span class="badge badge-<?= $document['status'] === 'active' ? 'ok' : 'off' ?>"><?= $document['status'] === 'active' ? 'فعال' : 'بایگانی' ?></span></td>
+                <td><span class="badge <?= e($reviewBadgeClass[$document['review_status']] ?? 'badge-pending') ?>"><?= e(kyc_document_review_status_label((string)$document['review_status'])) ?></span></td>
+                <td><?= e(jdate((string)$document['created_at'])) ?></td>
+                <td>
+                  <div class="toolbar" style="margin:0">
+                    <a class="btn btn-sm" href="/profile-document.php?id=<?= (int)$document['id'] ?>" target="_blank" rel="noopener">مشاهده</a>
+                    <?php if ($document['status'] === 'active'): ?>
+                    <form method="post" style="margin:0;display:inline-flex;gap:6px;align-items:center">
+                      <?= csrf_field() ?>
+                      <input type="hidden" name="do" value="document_review">
+                      <input type="hidden" name="organization_id" value="<?= (int)$detailId ?>">
+                      <input type="hidden" name="document_id" value="<?= (int)$document['id'] ?>">
+                      <input type="hidden" name="owner_user_id" value="<?= (int)$section['owner_user_id'] ?>">
+                      <input type="text" name="review_note" placeholder="یادداشت (اختیاری)" style="width:140px">
+                      <button class="btn btn-sm" name="review_status" value="approved">تأیید</button>
+                      <button class="btn btn-sm" name="review_status" value="rejected">رد</button>
+                    </form>
+                    <?php endif; ?>
+                  </div>
+                </td>
+              </tr>
+            <?php endforeach; ?>
+          </table>
+          </div>
+        </div>
+        <?php endforeach; ?>
+    <?php endif;
+else:
+    $statusFilter = (string)($_GET['status'] ?? '');
+    $search = (string)($_GET['q'] ?? '');
+    $requests = kyc_requests_list($statusFilter !== '' ? $statusFilter : null, $search);
+    ?>
+    <div class="card">
+      <form method="get" class="toolbar">
+        <label>وضعیت
+          <select name="status">
+            <option value="">همه</option>
+            <?php foreach (KYC_STATUSES as $value => $label): ?>
+              <option value="<?= e($value) ?>"<?= $statusFilter === $value ? ' selected' : '' ?>><?= e($label) ?></option>
+            <?php endforeach; ?>
+          </select>
+        </label>
+        <label>جستجو (نام سازمان/شرکت) <input type="text" name="q" value="<?= e($search) ?>"></label>
+        <button class="btn btn-sm">فیلتر</button>
+      </form>
+    </div>
+    <div class="card">
+      <div class="table-wrap">
+      <table>
+        <tr><th>سازمان</th><th>نوع حساب</th><th>نام حقوقی</th><th>وضعیت</th><th>ارسال</th><th></th></tr>
+        <?php foreach ($requests as $r): ?>
+          <tr>
+            <td><?= e((string)$r['organization_name']) ?></td>
+            <td><?= e(profile_account_type_label((string)($r['account_type'] ?? 'individual'))) ?></td>
+            <td><?= e((string)($r['legal_name'] ?? '')) ?: '—' ?></td>
+            <td><span class="badge <?= e(['draft'=>'badge-off','rejected'=>'badge-off','submitted'=>'badge-pending','under_review'=>'badge-pending','needs_correction'=>'badge-pending','approved'=>'badge-ok'][$r['status']] ?? 'badge-off') ?>"><?= e(kyc_status_label((string)$r['status'])) ?></span></td>
+            <td><?= $r['submitted_at'] ? e(jdate((string)$r['submitted_at'])) : '—' ?></td>
+            <td><a class="btn btn-sm" href="/kyc-review.php?id=<?= (int)$r['organization_id'] ?>">مشاهده</a></td>
+          </tr>
+        <?php endforeach; ?>
+        <?php if (!$requests): ?><tr><td colspan="6" class="empty">درخواستی یافت نشد.</td></tr><?php endif; ?>
+      </table>
+      </div>
+    </div>
+<?php endif; ?>
+<?php require __DIR__ . '/../app/views/footer.php'; ?>

--- a/public/profile.php
+++ b/public/profile.php
@@ -1,13 +1,14 @@
 <?php
 /**
  * ELLSMS — the user's own account page: password, personal profile, and (for members of an
- * organization) the company profile, address, low-credit alerts and documents
- * (docs/customer-profile.md).
+ * organization) the company profile, address, low-credit alerts, documents, KYC status/submission
+ * and allowed-IP management (docs/customer-profile.md, docs/profile-kyc.md).
  *
  * EDIT POLICY, enforced server-side on every branch below:
  *   - personal profile and personal documents: always the user's own, no permission needed;
- *   - company profile / address / alerts / organization documents: `settings.manage` only, i.e.
- *     owner and admin — an ordinary member READS them and cannot change the company's legal record.
+ *   - company profile / address / alerts / organization documents / account type / allowed IPs / KYC
+ *     submission: `settings.manage` only, i.e. owner and admin — an ordinary member READS them and
+ *     cannot change the company's legal record or trigger a KYC submission on the organization's behalf.
  *
  * The organization shown is the ACTIVE one (current_organization()). A user who belongs to two
  * organizations sees the company profile of whichever is active and never a merge of the two.
@@ -30,11 +31,16 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     $impersonationAction = [
         'password'              => 'account.password',
         'profile_personal'      => 'profile.personal',
+        'account_type'          => 'profile.organization',
         'profile_organization'  => 'profile.organization',
         'profile_address'       => 'profile.organization',
         'profile_notifications' => 'profile.organization',
         'document_upload'       => 'profile.documents',
         'document_archive'      => 'profile.documents',
+        'kyc_submit'            => 'profile.organization',
+        'allowed_ip_create'     => 'profile.organization',
+        'allowed_ip_delete'     => 'profile.organization',
+        'allowed_ip_toggle'     => 'profile.organization',
     ][$do] ?? null;
     if ($impersonationAction !== null && impersonation_guard_post($impersonationAction)) {
         redirect('/profile.php');
@@ -42,7 +48,10 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 
     // Every organization-scoped branch needs the same two things: an active organization and
     // settings.manage. Checked once, here, rather than repeated (and eventually forgotten) below.
-    $organizationScoped = in_array($do, ['profile_organization', 'profile_address', 'profile_notifications'], true)
+    $organizationScoped = in_array($do, [
+        'account_type', 'profile_organization', 'profile_address', 'profile_notifications',
+        'kyc_submit', 'allowed_ip_create', 'allowed_ip_delete', 'allowed_ip_toggle',
+    ], true)
         || ($do === 'document_upload' && ($_POST['owner'] ?? '') === 'organization')
         || ($do === 'document_archive' && ($_POST['owner'] ?? '') === 'organization');
     if ($organizationScoped && !($organizationId > 0 && $canManageOrganization)) {
@@ -81,8 +90,20 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         flash($result['ok'] ? 'success' : 'error', $result['ok']
             ? 'اطلاعات فردی ذخیره شد.'
             : profile_error_message((string)$result['reason']));
+    } elseif ($do === 'account_type') {
+        // A STANDALONE action, deliberately: switching حقیقی/حقوقی is a metadata decision the owner/
+        // admin should be able to make without re-submitting the entire company form, and it must
+        // NEVER blank out the other fields already on file (§13 — no silent data loss; the dormant
+        // side's data and documents simply stay stored and unused until switched back).
+        $current = profile_organization_get($organizationId);
+        $current['account_type'] = $_POST['account_type'] ?? $current['account_type'];
+        $result = profile_organization_save($organizationId, $current, (int)$me['id']);
+        flash($result['ok'] ? 'success' : 'error', $result['ok']
+            ? 'نوع حساب به‌روزرسانی شد.'
+            : profile_error_message((string)$result['reason']));
     } elseif ($do === 'profile_organization') {
         $result = profile_organization_save($organizationId, [
+            'account_type'                 => $_POST['account_type'] ?? 'individual',
             'legal_name'                   => $_POST['legal_name'] ?? '',
             'company_type'                 => $_POST['company_type'] ?? 'unspecified',
             'registration_number'          => $_POST['registration_number'] ?? '',
@@ -92,12 +113,15 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             'ceo_father_name'              => $_POST['ceo_father_name'] ?? '',
             'ceo_national_code'            => $_POST['ceo_national_code'] ?? '',
             'ceo_birth_date'               => profile_date_from_request('ceo_birth_date'),
+            'ceo_birth_city'               => $_POST['ceo_birth_city'] ?? '',
+            'ceo_mobile'                   => $_POST['ceo_mobile'] ?? '',
+            'ceo_email'                    => $_POST['ceo_email'] ?? '',
             'company_start_date'           => profile_date_from_request('company_start_date'),
             'company_expiry_date'          => profile_date_from_request('company_expiry_date'),
             'legal_representative_user_id' => $_POST['legal_representative_user_id'] ?? 0,
         ], (int)$me['id']);
         flash($result['ok'] ? 'success' : 'error', $result['ok']
-            ? 'اطلاعات سازمان ذخیره شد.'
+            ? 'اطلاعات ذخیره شد.'
             : profile_error_message((string)$result['reason']));
     } elseif ($do === 'profile_address') {
         $result = profile_address_save($organizationId, $_POST, (int)$me['id']);
@@ -125,6 +149,28 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             : ['user' => (int)$me['id']];
         $result = profile_document_archive($owner, (int)($_POST['document_id'] ?? 0), (int)$me['id']);
         flash($result['ok'] ? 'info' : 'error', $result['ok'] ? 'مدرک بایگانی شد.' : 'مدرک یافت نشد.');
+    } elseif ($do === 'kyc_submit') {
+        $accountType = profile_organization_get($organizationId)['account_type'] ?? 'individual';
+        $result = kyc_submit(
+            $organizationId, (int)$me['id'], $accountType,
+            profile_user_get((int)$me['id']), profile_organization_get($organizationId), profile_address_get($organizationId)
+        );
+        if ($result['ok']) {
+            flash('success', 'درخواست احراز هویت ارسال شد.');
+        } elseif (($result['reason'] ?? '') === 'incomplete') {
+            flash('error', 'برای ارسال، ابتدا موارد زیر را تکمیل کنید: ' . implode('، ', $result['missing']));
+        } else {
+            flash('error', 'در وضعیت فعلی امکان ارسال درخواست وجود ندارد.');
+        }
+    } elseif ($do === 'allowed_ip_create') {
+        $result = allowed_ip_create($organizationId, (string)($_POST['ip_or_cidr'] ?? ''), (string)($_POST['label'] ?? ''), (int)$me['id']);
+        flash($result['ok'] ? 'success' : 'error', $result['ok'] ? 'آدرس اضافه شد.' : allowed_ip_error_message((string)$result['reason']));
+    } elseif ($do === 'allowed_ip_delete') {
+        $result = allowed_ip_delete($organizationId, (int)($_POST['id'] ?? 0), (int)$me['id']);
+        flash($result['ok'] ? 'info' : 'error', $result['ok'] ? 'آدرس حذف شد.' : allowed_ip_error_message((string)$result['reason']));
+    } elseif ($do === 'allowed_ip_toggle') {
+        $result = allowed_ip_toggle($organizationId, (int)($_POST['id'] ?? 0), (int)$me['id']);
+        flash($result['ok'] ? 'info' : 'error', $result['ok'] ? 'وضعیت به‌روزرسانی شد.' : allowed_ip_error_message((string)$result['reason']));
     }
 
     redirect('/profile.php');
@@ -132,13 +178,34 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 
 $userProfile   = profile_user_get((int)$me['id']);
 $userDocuments = profile_documents_list(['user' => (int)$me['id']]);
-$userScore     = profile_user_completeness($userProfile);
 
 $organizationProfile = $organizationId > 0 ? profile_organization_get($organizationId) : null;
 $address             = $organizationId > 0 ? profile_address_get($organizationId) : null;
 $notifications       = $organizationId > 0 ? profile_notifications_get($organizationId) : null;
 $organizationDocuments = $organizationId > 0 ? profile_documents_list(['organization' => $organizationId]) : [];
-$organizationScore   = $organizationId > 0 ? profile_organization_completeness($organizationProfile, $address) : null;
+$allowedIps          = $organizationId > 0 ? allowed_ip_list($organizationId) : [];
+$accountType         = $organizationProfile['account_type'] ?? 'individual';
+// §13 — "no silent data loss": an organization that already has company/representative data on file
+// (e.g. from before an account_type switch, or set directly by an admin) keeps that section visible
+// even while account_type reads 'individual' — hiding a section never hides the DATA behind it, only
+// the default layout for an organization that has never touched it.
+$hasLegalData        = $organizationId > 0 && (
+    (string)($organizationProfile['legal_name'] ?? '') !== ''
+    || (string)($organizationProfile['national_id'] ?? '') !== ''
+    || (string)($organizationProfile['ceo_name'] ?? '') !== ''
+);
+$score               = $organizationId > 0
+    ? profile_account_completeness($accountType, $userProfile, $organizationProfile, $address)
+    : profile_user_completeness($userProfile);
+$kycRequest          = $organizationId > 0 ? kyc_request_get($organizationId) : null;
+$kycEligibility      = $organizationId > 0
+    ? kyc_can_submit($organizationId, (int)$me['id'], $accountType, $userProfile, $organizationProfile, $address)
+    : ['ok' => false, 'missing' => []];
+$kycBadgeClass = [
+    'draft' => 'badge-off', 'rejected' => 'badge-off',
+    'submitted' => 'badge-pending', 'under_review' => 'badge-pending', 'needs_correction' => 'badge-pending',
+    'approved' => 'badge-ok',
+][$kycRequest['status'] ?? 'draft'] ?? 'badge-off';
 
 require __DIR__ . '/../app/views/header.php';
 $impersonationNoticeAction = 'profile.personal';
@@ -155,12 +222,63 @@ $profileReadOnly = is_impersonating();
     <tr><th>نام و نام خانوادگی</th><td><?= e(trim((string)$me['first_name'] . ' ' . (string)$me['last_name'])) ?: '—' ?></td></tr>
     <tr><th>موبایل</th><td class="msisdn"><?= e((string)$me['mobile']) ?: '—' ?></td></tr>
     <tr><th>ایمیل</th><td class="ltr"><?= e((string)$me['email']) ?: '—' ?></td></tr>
+    <?php if ($organizationId > 0): ?>
+    <tr><th>تکمیل پروفایل</th><td><?= to_persian_digits((string)$score['percent']) ?>٪<?php if ($score['missing']): ?> <span class="hint" style="display:inline">— تکمیل‌نشده: <?= e(implode('، ', $score['missing'])) ?></span><?php endif; ?></td></tr>
+    <?php endif; ?>
   </table>
   </div>
 </div>
 
+<?php if ($organizationId > 0): ?>
 <div class="card">
-  <h2>اطلاعات فردی <span class="hint" style="display:inline">— تکمیل‌شده: <?= to_persian_digits((string)$userScore['percent']) ?>٪</span></h2>
+  <h2>وضعیت احراز هویت (KYC)
+    <span class="badge <?= e($kycBadgeClass) ?>" style="margin-inline-start:8px"><?= e(kyc_status_label((string)$kycRequest['status'])) ?></span>
+  </h2>
+  <?php if (in_array($kycRequest['status'], ['needs_correction', 'rejected'], true) && (string)$kycRequest['review_note'] !== ''): ?>
+    <div class="flash flash-error">یادداشت بازبین: <?= e((string)$kycRequest['review_note']) ?></div>
+  <?php endif; ?>
+  <?php if ($canManageOrganization && in_array($kycRequest['status'], ['draft', 'needs_correction', 'rejected'], true)): ?>
+    <?php if (!$kycEligibility['ok']): ?>
+      <p class="hint">پیش از ارسال باید تکمیل شود: <?= e(implode('، ', $kycEligibility['missing'])) ?></p>
+    <?php endif; ?>
+    <form method="post" style="margin:0">
+      <?= csrf_field() ?>
+      <input type="hidden" name="do" value="kyc_submit">
+      <button class="btn btn-primary btn-sm" <?= ($kycEligibility['ok'] && !$profileReadOnly) ? '' : 'disabled' ?>>ارسال درخواست احراز هویت</button>
+    </form>
+  <?php elseif (in_array($kycRequest['status'], ['submitted', 'under_review'], true)): ?>
+    <p class="hint">درخواست شما ثبت شده و در انتظار بررسی است.</p>
+  <?php elseif ($kycRequest['status'] === 'approved'): ?>
+    <p class="hint">احراز هویت این سازمان تأیید شده است.</p>
+  <?php endif; ?>
+</div>
+<?php endif; ?>
+
+<?php if ($organizationId > 0): ?>
+<div class="card">
+  <h2>نوع حساب</h2>
+  <form method="post">
+    <?= csrf_field() ?>
+    <input type="hidden" name="do" value="account_type">
+    <div class="toolbar">
+      <?php foreach (PROFILE_ACCOUNT_TYPES as $value => $label): ?>
+        <label style="display:inline-flex;align-items:center;gap:6px">
+          <input type="radio" name="account_type" value="<?= e($value) ?>"<?= $accountType === $value ? ' checked' : '' ?> <?= $canManageOrganization ? '' : 'disabled' ?>>
+          <?= e($label) ?>
+        </label>
+      <?php endforeach; ?>
+    </div>
+    <?php if ($canManageOrganization && !$profileReadOnly): ?>
+      <button class="btn btn-sm" style="margin-top:8px">اعمال نوع حساب</button>
+    <?php endif; ?>
+  </form>
+  <p class="hint">تغییر نوع حساب اطلاعات و مدارک بخش دیگر را حذف نمی‌کند؛ فقط بخش‌های نمایش‌داده‌شده را تغییر می‌دهد.</p>
+</div>
+<?php endif; ?>
+
+<?php if ($accountType !== 'legal' || $organizationId === 0): ?>
+<div class="card">
+  <h2>اطلاعات فردی</h2>
   <?php if (!empty($userProfile['from_legacy_kyc'])): ?>
     <div class="flash flash-info">بخشی از این اطلاعات از بخش «اطلاعات هویتی» قبلی خوانده شده است و با نخستین ذخیره‌سازی به‌روزرسانی می‌شود.</div>
   <?php endif; ?>
@@ -185,27 +303,42 @@ $profileReadOnly = is_impersonating();
       <button class="btn btn-primary">ذخیره‌ی اطلاعات فردی</button>
     <?php endif; ?>
   </form>
-  <?php if ($userScore['missing']): ?>
-    <p class="hint">تکمیل‌نشده: <?= e(implode('، ', $userScore['missing'])) ?></p>
-  <?php endif; ?>
 </div>
+<?php endif; ?>
 
-<?php if ($organizationId > 0): ?>
+<?php if ($organizationId > 0 && ($accountType === 'legal' || $hasLegalData)): ?>
 <div class="card">
-  <h2>اطلاعات سازمان — <?= e((string)$organization['name']) ?>
-    <span class="hint" style="display:inline">— تکمیل‌شده: <?= to_persian_digits((string)$organizationScore['percent']) ?>٪</span>
-  </h2>
+  <h2>اطلاعات نماینده</h2>
   <?php if (!$canManageOrganization): ?>
     <p class="hint">شما به این اطلاعات دسترسی مشاهده دارید؛ ویرایش آن‌ها نیازمند دسترسی مدیریت تنظیمات سازمان است.</p>
   <?php endif; ?>
   <form method="post">
     <?= csrf_field() ?>
     <input type="hidden" name="do" value="profile_organization">
+    <input type="hidden" name="account_type" value="legal">
+    <div class="grid grid-2">
+      <label>نام و نام خانوادگی نماینده <input type="text" name="ceo_name" value="<?= e((string)$organizationProfile['ceo_name']) ?>" maxlength="160" <?= $canManageOrganization ? '' : 'disabled' ?>></label>
+      <label>نام پدر <input type="text" name="ceo_father_name" value="<?= e((string)$organizationProfile['ceo_father_name']) ?>" maxlength="120" <?= $canManageOrganization ? '' : 'disabled' ?>></label>
+      <label>کد ملی <input type="text" name="ceo_national_code" class="ltr" value="<?= e((string)$organizationProfile['ceo_national_code']) ?>" maxlength="20" placeholder="۱۰ رقم" <?= $canManageOrganization ? '' : 'disabled' ?>></label>
+      <label>تاریخ تولد <?= jalali_date_select('ceo_birth_date', $organizationProfile['ceo_birth_date'] ?? null) ?></label>
+      <label>شهر تولد <input type="text" name="ceo_birth_city" value="<?= e((string)$organizationProfile['ceo_birth_city']) ?>" maxlength="60" <?= $canManageOrganization ? '' : 'disabled' ?>></label>
+      <label>موبایل <input type="text" name="ceo_mobile" class="ltr" value="<?= e((string)$organizationProfile['ceo_mobile']) ?>" maxlength="20" <?= $canManageOrganization ? '' : 'disabled' ?>></label>
+      <label>ایمیل <input type="text" name="ceo_email" class="ltr" value="<?= e((string)$organizationProfile['ceo_email']) ?>" maxlength="190" <?= $canManageOrganization ? '' : 'disabled' ?>></label>
+      <label>کاربر مرتبط (اختیاری)
+        <select name="legal_representative_user_id" <?= $canManageOrganization ? '' : 'disabled' ?>>
+          <option value="0">—</option>
+          <option value="<?= (int)$me['id'] ?>"<?= (int)($organizationProfile['legal_representative_user_id'] ?? 0) === (int)$me['id'] ? ' selected' : '' ?>><?= e((string)$me['username']) ?></option>
+        </select>
+      </label>
+    </div>
+    <div class="hr" style="margin:16px 0"></div>
+    <h3 style="margin-top:0">اطلاعات شرکت</h3>
     <div class="grid grid-2">
       <label>نام حقوقی <input type="text" name="legal_name" value="<?= e((string)$organizationProfile['legal_name']) ?>" maxlength="190" <?= $canManageOrganization ? '' : 'disabled' ?>></label>
       <label>نوع شرکت
         <select name="company_type" <?= $canManageOrganization ? '' : 'disabled' ?>>
           <?php foreach (PROFILE_COMPANY_TYPES as $value => $label): ?>
+            <?php if ($value === 'unspecified') continue; ?>
             <option value="<?= e($value) ?>"<?= ($organizationProfile['company_type'] ?? 'unspecified') === $value ? ' selected' : '' ?>><?= e($label) ?></option>
           <?php endforeach; ?>
         </select>
@@ -213,24 +346,19 @@ $profileReadOnly = is_impersonating();
       <label>شماره ثبت <input type="text" name="registration_number" class="ltr" value="<?= e((string)$organizationProfile['registration_number']) ?>" maxlength="40" <?= $canManageOrganization ? '' : 'disabled' ?>></label>
       <label>شناسه ملی شرکت <input type="text" name="national_id" class="ltr" value="<?= e((string)$organizationProfile['national_id']) ?>" maxlength="20" <?= $canManageOrganization ? '' : 'disabled' ?>></label>
       <label>کد اقتصادی <input type="text" name="economic_code" class="ltr" value="<?= e((string)$organizationProfile['economic_code']) ?>" maxlength="30" <?= $canManageOrganization ? '' : 'disabled' ?>></label>
-      <label>مدیرعامل <input type="text" name="ceo_name" value="<?= e((string)$organizationProfile['ceo_name']) ?>" maxlength="160" <?= $canManageOrganization ? '' : 'disabled' ?>></label>
-      <label>نام پدر مدیرعامل <input type="text" name="ceo_father_name" value="<?= e((string)$organizationProfile['ceo_father_name']) ?>" maxlength="120" <?= $canManageOrganization ? '' : 'disabled' ?>></label>
-      <label>کد ملی مدیرعامل <input type="text" name="ceo_national_code" class="ltr" value="<?= e((string)$organizationProfile['ceo_national_code']) ?>" maxlength="20" <?= $canManageOrganization ? '' : 'disabled' ?>></label>
-      <label>تاریخ تولد مدیرعامل <?= jalali_date_select('ceo_birth_date', $organizationProfile['ceo_birth_date'] ?? null) ?></label>
       <label>تاریخ شروع فعالیت <?= jalali_date_select('company_start_date', $organizationProfile['company_start_date'] ?? null) ?></label>
       <label>تاریخ انقضا <?= jalali_date_select('company_expiry_date', $organizationProfile['company_expiry_date'] ?? null, 10) ?></label>
     </div>
     <?php if ($canManageOrganization && !$profileReadOnly): ?>
-      <button class="btn btn-primary">ذخیره‌ی اطلاعات سازمان</button>
+      <button class="btn btn-primary" style="margin-top:12px">ذخیره‌ی اطلاعات نماینده و شرکت</button>
     <?php endif; ?>
   </form>
-  <?php if ($organizationScore['missing']): ?>
-    <p class="hint">تکمیل‌نشده: <?= e(implode('، ', $organizationScore['missing'])) ?></p>
-  <?php endif; ?>
 </div>
+<?php endif; ?>
 
+<?php if ($organizationId > 0): ?>
 <div class="card">
-  <h2>آدرس سازمان</h2>
+  <h2><?= $accountType === 'legal' ? 'آدرس شرکت' : 'آدرس و تماس' ?></h2>
   <form method="post">
     <?= csrf_field() ?>
     <input type="hidden" name="do" value="profile_address">
@@ -251,47 +379,35 @@ $profileReadOnly = is_impersonating();
     <?php endif; ?>
   </form>
 </div>
-
-<div class="card">
-  <h2>تنظیمات اعلان اعتبار</h2>
-  <p class="hint">آستانه بر حسب «واحد اعتبار» است و فقط یک تنظیم است؛ موجودی کیف پول را تغییر نمی‌دهد.</p>
-  <form method="post">
-    <?= csrf_field() ?>
-    <input type="hidden" name="do" value="profile_notifications">
-    <div class="grid grid-2">
-      <label><input type="checkbox" name="low_credit_alert_enabled" value="1"<?= $notifications['low_credit_alert_enabled'] ? ' checked' : '' ?> <?= $canManageOrganization ? '' : 'disabled' ?>> هشدار اعتبار کم فعال باشد</label>
-      <label>آستانه‌ی اعتبار کم <input type="text" name="low_credit_threshold" class="ltr" value="<?= e((string)$notifications['low_credit_threshold']) ?>" <?= $canManageOrganization ? '' : 'disabled' ?>></label>
-      <label><input type="checkbox" name="email_alert_enabled" value="1"<?= $notifications['email_alert_enabled'] ? ' checked' : '' ?> <?= $canManageOrganization ? '' : 'disabled' ?>> اعلان ایمیلی</label>
-      <label><input type="checkbox" name="sms_alert_enabled" value="1"<?= $notifications['sms_alert_enabled'] ? ' checked' : '' ?> <?= $canManageOrganization ? '' : 'disabled' ?>> اعلان پیامکی</label>
-      <label>ایمیل اعلان <input type="text" name="alert_email" class="ltr" value="<?= e((string)$notifications['alert_email']) ?>" maxlength="190" <?= $canManageOrganization ? '' : 'disabled' ?>></label>
-      <label>موبایل اعلان <input type="text" name="alert_mobile" class="ltr" value="<?= e((string)$notifications['alert_mobile']) ?>" maxlength="20" <?= $canManageOrganization ? '' : 'disabled' ?>></label>
-    </div>
-    <?php if ($canManageOrganization && !$profileReadOnly): ?>
-      <button class="btn btn-primary">ذخیره‌ی تنظیمات</button>
-    <?php endif; ?>
-  </form>
-</div>
 <?php endif; ?>
 
 <?php
 // Both document sections share one presentation; only the owner and the permitted type list differ.
-$documentSections = [
-    ['owner' => 'user', 'title' => 'مدارک فردی', 'types' => PROFILE_USER_DOCUMENT_TYPES, 'documents' => $userDocuments, 'editable' => !$profileReadOnly],
-];
-if ($organizationId > 0) {
-    $documentSections[] = ['owner' => 'organization', 'title' => 'مدارک سازمان', 'types' => PROFILE_ORGANIZATION_DOCUMENT_TYPES, 'documents' => $organizationDocuments, 'editable' => $canManageOrganization && !$profileReadOnly];
+// Per-document KYC review status is shown alongside the archive/upload controls (§9/§15).
+$documentSections = $accountType === 'legal'
+    ? [['owner' => 'organization', 'title' => 'مدارک احراز هویت', 'types' => PROFILE_ORGANIZATION_DOCUMENT_TYPES, 'documents' => $organizationDocuments, 'editable' => $canManageOrganization && !$profileReadOnly]]
+    : [['owner' => 'user', 'title' => 'مدارک احراز هویت', 'types' => PROFILE_USER_DOCUMENT_TYPES, 'documents' => $userDocuments, 'editable' => !$profileReadOnly]];
+if ($organizationId === 0) {
+    $documentSections = [['owner' => 'user', 'title' => 'مدارک احراز هویت', 'types' => PROFILE_USER_DOCUMENT_TYPES, 'documents' => $userDocuments, 'editable' => !$profileReadOnly]];
 }
+$reviewBadgeClass = ['pending' => 'badge-pending', 'approved' => 'badge-ok', 'rejected' => 'badge-off'];
 ?>
 <?php foreach ($documentSections as $section): ?>
 <div class="card">
   <h2><?= e($section['title']) ?></h2>
   <div class="table-wrap">
   <table>
-    <tr><th>نوع مدرک</th><th>وضعیت</th><th>تاریخ بارگذاری</th><th></th></tr>
+    <tr><th>نوع مدرک</th><th>وضعیت</th><th>بررسی</th><th>تاریخ بارگذاری</th><th></th></tr>
     <?php foreach ($section['documents'] as $document): ?>
       <tr>
         <td><?= e(profile_document_type_label((string)$document['document_type'])) ?></td>
         <td><span class="badge badge-<?= $document['status'] === 'active' ? 'ok' : 'off' ?>"><?= $document['status'] === 'active' ? 'فعال' : 'بایگانی' ?></span></td>
+        <td>
+          <span class="badge <?= e($reviewBadgeClass[$document['review_status']] ?? 'badge-pending') ?>"><?= e(kyc_document_review_status_label((string)$document['review_status'])) ?></span>
+          <?php if ($document['review_status'] === 'rejected' && (string)$document['review_note'] !== ''): ?>
+            <div class="hint"><?= e((string)$document['review_note']) ?></div>
+          <?php endif; ?>
+        </td>
         <td><?= e(jdate((string)$document['created_at'])) ?></td>
         <td>
           <div class="toolbar" style="margin:0">
@@ -309,7 +425,7 @@ if ($organizationId > 0) {
         </td>
       </tr>
     <?php endforeach; ?>
-    <?php if (!$section['documents']): ?><tr><td colspan="4" class="empty">هنوز مدرکی بارگذاری نشده است.</td></tr><?php endif; ?>
+    <?php if (!$section['documents']): ?><tr><td colspan="5" class="empty">هنوز مدرکی بارگذاری نشده است.</td></tr><?php endif; ?>
   </table>
   </div>
   <?php if ($section['editable']): ?>
@@ -327,13 +443,14 @@ if ($organizationId > 0) {
       <label>فایل <input type="file" name="document" accept=".jpg,.jpeg,.png,.webp,.pdf" required></label>
       <button class="btn btn-primary btn-sm">بارگذاری</button>
     </form>
-    <p class="hint">فرمت‌های مجاز: JPG، PNG، WEBP، PDF — حداکثر ۸ مگابایت. بارگذاری مدرک جدید از همین نوع، نسخه‌ی قبلی را بایگانی می‌کند.</p>
+    <p class="hint">فرمت‌های مجاز: JPG، PNG، WEBP، PDF — حداکثر ۸ مگابایت. بارگذاری مدرک جدید از همین نوع، نسخه‌ی قبلی را بایگانی و وضعیت بررسی را به «در انتظار بررسی» بازمی‌گرداند.</p>
   <?php endif; ?>
 </div>
 <?php endforeach; ?>
 
 <div class="card">
-  <h2>تغییر رمز عبور</h2>
+  <h2>امنیت و اعلان‌ها</h2>
+  <h3 style="margin-top:0">تغییر رمز عبور</h3>
   <form method="post">
     <?= csrf_field() ?>
     <input type="hidden" name="do" value="password">
@@ -346,5 +463,71 @@ if ($organizationId > 0) {
       <button class="btn btn-primary">تغییر رمز عبور</button>
     <?php endif; ?>
   </form>
+
+  <?php if ($organizationId > 0): ?>
+  <div class="hr" style="margin:16px 0"></div>
+  <h3>هشدار اعتبار کم</h3>
+  <p class="hint">آستانه بر حسب «واحد اعتبار» است و فقط یک تنظیم است؛ موجودی کیف پول را تغییر نمی‌دهد.</p>
+  <form method="post">
+    <?= csrf_field() ?>
+    <input type="hidden" name="do" value="profile_notifications">
+    <div class="grid grid-2">
+      <label><input type="checkbox" name="low_credit_alert_enabled" value="1"<?= $notifications['low_credit_alert_enabled'] ? ' checked' : '' ?> <?= $canManageOrganization ? '' : 'disabled' ?>> هشدار اعتبار کم فعال باشد</label>
+      <label>آستانه‌ی اعتبار کم <input type="text" name="low_credit_threshold" class="ltr" value="<?= e((string)$notifications['low_credit_threshold']) ?>" <?= $canManageOrganization ? '' : 'disabled' ?>></label>
+      <label><input type="checkbox" name="email_alert_enabled" value="1"<?= $notifications['email_alert_enabled'] ? ' checked' : '' ?> <?= $canManageOrganization ? '' : 'disabled' ?>> اعلان ایمیلی</label>
+      <label><input type="checkbox" name="sms_alert_enabled" value="1"<?= $notifications['sms_alert_enabled'] ? ' checked' : '' ?> <?= $canManageOrganization ? '' : 'disabled' ?>> اعلان پیامکی</label>
+      <label>ایمیل اعلان <input type="text" name="alert_email" class="ltr" value="<?= e((string)$notifications['alert_email']) ?>" maxlength="190" <?= $canManageOrganization ? '' : 'disabled' ?>></label>
+      <label>موبایل اعلان <input type="text" name="alert_mobile" class="ltr" value="<?= e((string)$notifications['alert_mobile']) ?>" maxlength="20" <?= $canManageOrganization ? '' : 'disabled' ?>></label>
+    </div>
+    <?php if ($canManageOrganization && !$profileReadOnly): ?>
+      <button class="btn btn-primary">ذخیره‌ی تنظیمات</button>
+    <?php endif; ?>
+  </form>
+
+  <div class="hr" style="margin:16px 0"></div>
+  <h3>آدرس‌های IP مجاز</h3>
+  <p class="hint">این فهرست فقط برای ثبت و مدیریت است؛ اعمال محدودیت ورود بر اساس IP در حال حاضر در این نسخه فعال نیست (docs/profile-kyc.md).</p>
+  <div class="table-wrap">
+  <table>
+    <tr><th>آدرس / محدوده</th><th>برچسب</th><th>وضعیت</th><th>تاریخ ثبت</th><th></th></tr>
+    <?php foreach ($allowedIps as $ip): ?>
+      <tr>
+        <td class="ltr"><?= e((string)$ip['ip_or_cidr']) ?></td>
+        <td><?= e((string)$ip['label']) ?: '—' ?></td>
+        <td><span class="badge <?= $ip['status'] === 'active' ? 'badge-ok' : 'badge-off' ?>"><?= $ip['status'] === 'active' ? 'فعال' : 'غیرفعال' ?></span></td>
+        <td><?= e(jdate((string)$ip['created_at'])) ?></td>
+        <td>
+          <?php if ($canManageOrganization && !$profileReadOnly): ?>
+          <div class="toolbar" style="margin:0">
+            <form method="post" style="margin:0">
+              <?= csrf_field() ?>
+              <input type="hidden" name="do" value="allowed_ip_toggle">
+              <input type="hidden" name="id" value="<?= (int)$ip['id'] ?>">
+              <button class="btn btn-sm"><?= $ip['status'] === 'active' ? 'غیرفعال‌سازی' : 'فعال‌سازی' ?></button>
+            </form>
+            <form method="post" style="margin:0" onsubmit="return confirm('این آدرس حذف شود؟');">
+              <?= csrf_field() ?>
+              <input type="hidden" name="do" value="allowed_ip_delete">
+              <input type="hidden" name="id" value="<?= (int)$ip['id'] ?>">
+              <button class="btn btn-sm">حذف</button>
+            </form>
+          </div>
+          <?php endif; ?>
+        </td>
+      </tr>
+    <?php endforeach; ?>
+    <?php if (!$allowedIps): ?><tr><td colspan="5" class="empty">آدرسی ثبت نشده است.</td></tr><?php endif; ?>
+  </table>
+  </div>
+  <?php if ($canManageOrganization && !$profileReadOnly): ?>
+    <form method="post" class="toolbar" style="margin-top:10px">
+      <?= csrf_field() ?>
+      <input type="hidden" name="do" value="allowed_ip_create">
+      <label>آدرس IP یا CIDR <input type="text" name="ip_or_cidr" class="ltr" placeholder="203.0.113.10 یا 203.0.113.0/24" required></label>
+      <label>برچسب <input type="text" name="label" maxlength="120" placeholder="مثلاً دفتر مرکزی"></label>
+      <button class="btn btn-primary btn-sm">افزودن</button>
+    </form>
+  <?php endif; ?>
+  <?php endif; ?>
 </div>
 <?php require __DIR__ . '/../app/views/footer.php'; ?>

--- a/tests/Integration/KycWorkflowIntegrationTest.php
+++ b/tests/Integration/KycWorkflowIntegrationTest.php
@@ -1,0 +1,356 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration;
+
+/**
+ * The DB-touching half of the KYC workflow (docs/profile-kyc.md): account type persistence, the
+ * ellsms_kyc_requests state machine, per-document review, submission eligibility, and — critically —
+ * tenant isolation across all of it. The pure logic (transition table shape, digit normalization,
+ * gating decision) is covered without a database in tests/Unit/KycWorkflowTest.php.
+ */
+final class KycWorkflowIntegrationTest extends IntegrationTestCase
+{
+    private int $ownerId;
+    private int $memberId;
+    private int $organizationId;
+    private int $otherOwnerId;
+    private int $otherOrganizationId;
+
+    private array $documentFilesBefore = [];
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $_SESSION = [];
+        $this->documentFilesBefore = is_dir(\profile_document_dir())
+            ? (array)(glob(\profile_document_dir() . '/*') ?: [])
+            : [];
+
+        $this->ownerId = $this->makeUser();
+        $this->memberId = $this->makeUser();
+        $result = \create_organization($this->ownerId, 'KYC Org ' . bin2hex(random_bytes(3)));
+        $this->assertTrue($result['ok']);
+        $this->organizationId = (int)$result['organization_id'];
+        $this->addMember($this->organizationId, $this->memberId, 'member');
+
+        $this->otherOwnerId = $this->makeUser();
+        $other = \create_organization($this->otherOwnerId, 'KYC Org B ' . bin2hex(random_bytes(3)));
+        $this->otherOrganizationId = (int)$other['organization_id'];
+    }
+
+    protected function tearDown(): void
+    {
+        $_SESSION = [];
+        foreach ((array)(glob(\profile_document_dir() . '/*') ?: []) as $path) {
+            if (!in_array($path, $this->documentFilesBefore, true)) {
+                @unlink($path);
+            }
+        }
+        parent::tearDown();
+    }
+
+    private function addMember(int $organizationId, int $userId, string $role): void
+    {
+        db()->prepare("INSERT INTO ellsms_organization_memberships (organization_id, user_id, role, status) VALUES (?,?,?, 'active')")
+            ->execute([$organizationId, $userId, $role]);
+    }
+
+    private function fakeUpload(string $field, string $bytes, string $filename): string
+    {
+        $tmp = sys_get_temp_dir() . '/kyc_' . bin2hex(random_bytes(6));
+        file_put_contents($tmp, $bytes);
+        $_FILES[$field] = [
+            'name' => $filename, 'type' => 'application/octet-stream', 'tmp_name' => $tmp,
+            'error' => UPLOAD_ERR_OK, 'size' => strlen($bytes),
+        ];
+        return $tmp;
+    }
+
+    /** A minimal 1x1 PNG — real bytes, so mime_content_type() genuinely detects image/png. */
+    private const PNG_BYTES = "\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR\x00\x00\x00\x01\x00\x00\x00\x01\x08\x02\x00\x00\x00\x90wS\xde\x00\x00\x00\x0cIDATx\x9cc\xf8\xcf\xc0\x00\x00\x03\x01\x01\x00\x18\xdd\x8d\xb0\x00\x00\x00\x00IEND\xaeB`\x82";
+
+    /* ---------- Account type ---------- */
+
+    public function testNewOrganizationDefaultsToIndividualAccountType(): void
+    {
+        $profile = \profile_organization_get($this->organizationId);
+        $this->assertSame('individual', $profile['account_type']);
+    }
+
+    public function testAccountTypeSwitchIsPersistedAndAudited(): void
+    {
+        $result = \profile_organization_save($this->organizationId, ['account_type' => 'legal'], $this->ownerId);
+        $this->assertTrue($result['ok']);
+        $this->assertSame('legal', \profile_organization_get($this->organizationId)['account_type']);
+
+        $st = db()->prepare("SELECT action FROM ellsms_audit_log WHERE action = 'profile.account_type_changed' AND details LIKE ? ORDER BY id DESC LIMIT 1");
+        $st->execute(["%org={$this->organizationId}%"]);
+        $this->assertNotFalse($st->fetch(), 'account type switch must be audited');
+    }
+
+    public function testSwitchingAccountTypeDoesNotDeleteTheOtherSidesData(): void
+    {
+        \profile_organization_save($this->organizationId, ['account_type' => 'legal', 'legal_name' => 'شرکت آزمایشی'], $this->ownerId);
+        \profile_user_save($this->ownerId, ['father_name' => 'رضا'], $this->ownerId);
+
+        // Switch back to individual — the company data (legal_name) must survive, dormant.
+        \profile_organization_save($this->organizationId, ['account_type' => 'individual'], $this->ownerId);
+        $profile = \profile_organization_get($this->organizationId);
+        $this->assertSame('individual', $profile['account_type']);
+        $this->assertSame('شرکت آزمایشی', $profile['legal_name'], 'legal_name must not be silently wiped by an account_type switch');
+        $this->assertSame('رضا', \profile_user_get($this->ownerId)['father_name']);
+    }
+
+    /* ---------- State machine ---------- */
+
+    public function testFreshOrganizationStartsInDraft(): void
+    {
+        $this->assertSame('draft', \kyc_request_get($this->organizationId)['status']);
+    }
+
+    public function testDraftToSubmittedSucceeds(): void
+    {
+        $result = \kyc_transition($this->organizationId, 'submitted', $this->ownerId);
+        $this->assertTrue($result['ok']);
+        $request = \kyc_request_get($this->organizationId);
+        $this->assertSame('submitted', $request['status']);
+        $this->assertNotNull($request['submitted_at']);
+    }
+
+    public function testFullHappyPathToApproved(): void
+    {
+        $this->assertTrue(\kyc_transition($this->organizationId, 'submitted', $this->ownerId)['ok']);
+        $this->assertTrue(\kyc_transition($this->organizationId, 'under_review', 999)['ok']);
+        $this->assertTrue(\kyc_transition($this->organizationId, 'approved', 999, 'همه چیز درست است')['ok']);
+
+        $request = \kyc_request_get($this->organizationId);
+        $this->assertSame('approved', $request['status']);
+        $this->assertSame(999, (int)$request['reviewed_by_user_id']);
+        $this->assertNotNull($request['reviewed_at']);
+    }
+
+    public function testRejectedCanBeResubmitted(): void
+    {
+        \kyc_transition($this->organizationId, 'submitted', $this->ownerId);
+        \kyc_transition($this->organizationId, 'under_review', 999);
+        \kyc_transition($this->organizationId, 'rejected', 999, 'مدرک ناخوانا');
+        $result = \kyc_transition($this->organizationId, 'submitted', $this->ownerId);
+        $this->assertTrue($result['ok']);
+        $this->assertSame('submitted', \kyc_request_get($this->organizationId)['status']);
+    }
+
+    public function testNeedsCorrectionCanBeResubmitted(): void
+    {
+        \kyc_transition($this->organizationId, 'submitted', $this->ownerId);
+        \kyc_transition($this->organizationId, 'under_review', 999);
+        \kyc_transition($this->organizationId, 'needs_correction', 999, 'کد ملی ناقص است');
+        $this->assertTrue(\kyc_transition($this->organizationId, 'submitted', $this->ownerId)['ok']);
+    }
+
+    public function testDraftCannotJumpToApproved(): void
+    {
+        $result = \kyc_transition($this->organizationId, 'approved', 999);
+        $this->assertFalse($result['ok']);
+        $this->assertSame('invalid_transition', $result['reason']);
+        $this->assertSame('draft', \kyc_request_get($this->organizationId)['status'], 'a rejected transition must not mutate state');
+    }
+
+    public function testApprovedIsTerminalAndRejectsAnyFurtherTransition(): void
+    {
+        \kyc_transition($this->organizationId, 'submitted', $this->ownerId);
+        \kyc_transition($this->organizationId, 'under_review', 999);
+        \kyc_transition($this->organizationId, 'approved', 999);
+
+        $result = \kyc_transition($this->organizationId, 'submitted', $this->ownerId);
+        $this->assertFalse($result['ok']);
+        $this->assertSame('approved', \kyc_request_get($this->organizationId)['status']);
+    }
+
+    public function testSubmittedCannotSkipReviewToApproved(): void
+    {
+        \kyc_transition($this->organizationId, 'submitted', $this->ownerId);
+        $result = \kyc_transition($this->organizationId, 'approved', 999);
+        $this->assertFalse($result['ok']);
+    }
+
+    public function testUnknownStatusIsRejected(): void
+    {
+        $result = \kyc_transition($this->organizationId, 'totally_made_up', 999);
+        $this->assertFalse($result['ok']);
+        $this->assertSame('invalid_status', $result['reason']);
+    }
+
+    /* ---------- Submission eligibility (§16) ---------- */
+
+    public function testSubmitFailsWhenProfileAndDocumentsAreIncomplete(): void
+    {
+        $result = \kyc_submit(
+            $this->organizationId, $this->ownerId, 'individual',
+            \profile_user_get($this->ownerId), \profile_organization_get($this->organizationId), \profile_address_get($this->organizationId)
+        );
+        $this->assertFalse($result['ok']);
+        $this->assertSame('incomplete', $result['reason']);
+        $this->assertNotEmpty($result['missing']);
+        $this->assertSame('draft', \kyc_request_get($this->organizationId)['status']);
+    }
+
+    public function testSubmitSucceedsOnceIndividualProfileAddressAndDocumentsArePresent(): void
+    {
+        \profile_user_save($this->ownerId, ['father_name' => 'رضا', 'national_code' => '1234567890'], $this->ownerId);
+        \profile_address_save($this->organizationId, ['city' => 'تهران', 'postal_code' => '1234567890'], $this->ownerId);
+        foreach (\PROFILE_REQUIRED_DOCUMENTS_INDIVIDUAL as $type) {
+            $this->fakeUpload('document', self::PNG_BYTES, 'x.png');
+            \profile_document_store(['user' => $this->ownerId], $type, 'document', $this->ownerId);
+        }
+
+        $result = \kyc_submit(
+            $this->organizationId, $this->ownerId, 'individual',
+            \profile_user_get($this->ownerId), \profile_organization_get($this->organizationId), \profile_address_get($this->organizationId)
+        );
+        $this->assertTrue($result['ok']);
+        $this->assertSame('submitted', \kyc_request_get($this->organizationId)['status']);
+    }
+
+    public function testLegalSubmissionRequiresCompanyFieldsAndOrganizationDocuments(): void
+    {
+        \profile_organization_save($this->organizationId, [
+            'account_type' => 'legal', 'legal_name' => 'شرکت نمونه', 'national_id' => '10861234567',
+            'ceo_name' => 'مدیر عامل', 'ceo_national_code' => '0987654321',
+        ], $this->ownerId);
+        \profile_address_save($this->organizationId, ['city' => 'تهران', 'postal_code' => '1234567890'], $this->ownerId);
+
+        $before = \kyc_can_submit($this->organizationId, $this->ownerId, 'legal', [], \profile_organization_get($this->organizationId), \profile_address_get($this->organizationId));
+        $this->assertFalse($before['ok'], 'must still be missing organization documents');
+
+        foreach (\PROFILE_REQUIRED_DOCUMENTS_LEGAL as $type) {
+            $this->fakeUpload('document', self::PNG_BYTES, 'x.png');
+            \profile_document_store(['organization' => $this->organizationId], $type, 'document', $this->ownerId);
+        }
+        $after = \kyc_can_submit($this->organizationId, $this->ownerId, 'legal', [], \profile_organization_get($this->organizationId), \profile_address_get($this->organizationId));
+        $this->assertTrue($after['ok']);
+    }
+
+    /* ---------- Per-document review (§9/§17) ---------- */
+
+    public function testUploadedDocumentStartsPending(): void
+    {
+        $this->fakeUpload('document', self::PNG_BYTES, 'x.png');
+        $result = \profile_document_store(['user' => $this->ownerId], 'national_card', 'document', $this->ownerId);
+        $document = \profile_document_find((int)$result['document_id']);
+        $this->assertSame('pending', $document['review_status']);
+    }
+
+    public function testDocumentApprovalIsRecordedWithReviewer(): void
+    {
+        $this->fakeUpload('document', self::PNG_BYTES, 'x.png');
+        $result = \profile_document_store(['user' => $this->ownerId], 'national_card', 'document', $this->ownerId);
+        $documentId = (int)$result['document_id'];
+
+        $review = \kyc_document_review($documentId, 'approved', 999, 'واضح و معتبر');
+        $this->assertTrue($review['ok']);
+
+        $document = \profile_document_find($documentId);
+        $this->assertSame('approved', $document['review_status']);
+        $this->assertSame(999, (int)$document['reviewed_by_user_id']);
+        $this->assertSame('واضح و معتبر', $document['review_note']);
+    }
+
+    public function testDocumentRejectionRecordsNote(): void
+    {
+        $this->fakeUpload('document', self::PNG_BYTES, 'x.png');
+        $result = \profile_document_store(['user' => $this->ownerId], 'national_card', 'document', $this->ownerId);
+        \kyc_document_review((int)$result['document_id'], 'rejected', 999, 'تصویر تار است');
+        $document = \profile_document_find((int)$result['document_id']);
+        $this->assertSame('rejected', $document['review_status']);
+        $this->assertSame('تصویر تار است', $document['review_note']);
+    }
+
+    public function testReplacingADocumentResetsReviewStatusToPendingOnTheNewRow(): void
+    {
+        $this->fakeUpload('document', self::PNG_BYTES, 'first.png');
+        $first = \profile_document_store(['user' => $this->ownerId], 'national_card', 'document', $this->ownerId);
+        \kyc_document_review((int)$first['document_id'], 'rejected', 999, 'ناخوانا');
+
+        $this->fakeUpload('document', self::PNG_BYTES, 'second.png');
+        $second = \profile_document_store(['user' => $this->ownerId], 'national_card', 'document', $this->ownerId);
+        $newDocument = \profile_document_find((int)$second['document_id']);
+        $this->assertSame('pending', $newDocument['review_status'], 'a freshly uploaded replacement must not inherit the old rejection');
+    }
+
+    /* ---------- Tenant isolation (§24) ---------- */
+
+    public function testKycRequestsAreIsolatedPerOrganization(): void
+    {
+        \kyc_transition($this->organizationId, 'submitted', $this->ownerId);
+        $this->assertSame('submitted', \kyc_request_get($this->organizationId)['status']);
+        $this->assertSame('draft', \kyc_request_get($this->otherOrganizationId)['status'], 'a transition on one organization must never affect another');
+    }
+
+    public function testOrganizationCannotReviewAnotherOrganizationsDocumentThroughItsOwnScope(): void
+    {
+        $this->fakeUpload('document', self::PNG_BYTES, 'x.png');
+        $result = \profile_document_store(['organization' => $this->organizationId], 'incorporation_notice', 'document', $this->ownerId);
+        $document = \profile_document_find((int)$result['document_id']);
+
+        // Mirrors the guard in public/kyc-review.php: a document must belong to the organization the
+        // admin screen is scoped to before any review action is accepted.
+        $this->assertFalse(\profile_document_belongs_to($document, 'organization', $this->otherOrganizationId));
+        $this->assertTrue(\profile_document_belongs_to($document, 'organization', $this->organizationId));
+    }
+
+    public function testAccountTypeChangeOnOneOrganizationDoesNotAffectAnother(): void
+    {
+        \profile_organization_save($this->organizationId, ['account_type' => 'legal'], $this->ownerId);
+        $this->assertSame('individual', \profile_organization_get($this->otherOrganizationId)['account_type']);
+    }
+
+    /* ---------- Allowed IPs (§20) ---------- */
+
+    public function testAllowedIpCrudAndAudit(): void
+    {
+        $create = \allowed_ip_create($this->organizationId, '203.0.113.5', 'دفتر', $this->ownerId);
+        $this->assertTrue($create['ok']);
+        $ips = \allowed_ip_list($this->organizationId);
+        $this->assertCount(1, $ips);
+        $this->assertSame('203.0.113.5', $ips[0]['ip_or_cidr']);
+
+        $st = db()->prepare("SELECT id FROM ellsms_audit_log WHERE action = 'allowed_ip.created' ORDER BY id DESC LIMIT 1");
+        $st->execute();
+        $this->assertNotFalse($st->fetch());
+
+        $delete = \allowed_ip_delete($this->organizationId, (int)$create['id'], $this->ownerId);
+        $this->assertTrue($delete['ok']);
+        $this->assertCount(0, \allowed_ip_list($this->organizationId));
+    }
+
+    public function testAllowedIpIsScopedToItsOwnOrganization(): void
+    {
+        $create = \allowed_ip_create($this->organizationId, '203.0.113.5', '', $this->ownerId);
+        $delete = \allowed_ip_delete($this->otherOrganizationId, (int)$create['id'], $this->otherOwnerId);
+        $this->assertFalse($delete['ok'], 'deleting another organization\'s allowed IP by id must fail');
+        $this->assertCount(1, \allowed_ip_list($this->organizationId));
+    }
+
+    public function testDuplicateAllowedIpForSameOrganizationIsRejected(): void
+    {
+        \allowed_ip_create($this->organizationId, '203.0.113.5', '', $this->ownerId);
+        $second = \allowed_ip_create($this->organizationId, '203.0.113.5', '', $this->ownerId);
+        $this->assertFalse($second['ok']);
+        $this->assertSame('duplicate', $second['reason']);
+    }
+
+    /* ---------- Feature gating end-to-end (§22) ---------- */
+
+    public function testFeatureAllowedUsesRealKycStatusForAnApprovedOrganization(): void
+    {
+        \kyc_transition($this->organizationId, 'submitted', $this->ownerId);
+        \kyc_transition($this->organizationId, 'under_review', 999);
+        \kyc_transition($this->organizationId, 'approved', 999);
+
+        $status = \kyc_request_get($this->organizationId)['status'];
+        $this->assertTrue(\kyc_feature_allowed_for_status(true, $status));
+        $this->assertTrue(\kyc_feature_allowed_for_status(false, $status));
+    }
+}

--- a/tests/Unit/KycWorkflowTest.php
+++ b/tests/Unit/KycWorkflowTest.php
@@ -1,0 +1,191 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * The pure (no database) half of the KYC workflow: the state-machine transition table
+ * (KYC_TRANSITIONS), the digit/identifier normalization helpers, account-type completeness scoring,
+ * feature-gate defaults, and allowed-IP validation. Every one of these is a plain function over
+ * already-fetched arrays/strings, which is exactly what makes it unit-testable without a real
+ * database — the DB-touching half (kyc_transition(), kyc_submit(), document review) is covered by
+ * tests/Integration/KycWorkflowIntegrationTest.php instead.
+ */
+final class KycWorkflowTest extends TestCase
+{
+    /* ---------- State machine ---------- */
+
+    public function testDraftMayOnlyMoveToSubmitted(): void
+    {
+        $this->assertSame(['submitted'], \KYC_TRANSITIONS['draft']);
+    }
+
+    public function testUnderReviewMayMoveToApprovedNeedsCorrectionOrRejected(): void
+    {
+        $this->assertEqualsCanonicalizing(['approved', 'needs_correction', 'rejected'], \KYC_TRANSITIONS['under_review']);
+    }
+
+    public function testApprovedIsTerminal(): void
+    {
+        $this->assertSame([], \KYC_TRANSITIONS['approved']);
+    }
+
+    public function testNeedsCorrectionAndRejectedBothReturnToSubmitted(): void
+    {
+        $this->assertSame(['submitted'], \KYC_TRANSITIONS['needs_correction']);
+        $this->assertSame(['submitted'], \KYC_TRANSITIONS['rejected']);
+    }
+
+    /** Every status in the catalog has a (possibly empty) transition list — nothing is undefined. */
+    public function testEveryStatusHasATransitionEntry(): void
+    {
+        foreach (array_keys(\KYC_STATUSES) as $status) {
+            $this->assertArrayHasKey($status, \KYC_TRANSITIONS);
+        }
+    }
+
+    /** An invalid/arbitrary transition (e.g. draft -> approved, skipping review) must not be listed. */
+    public function testDraftCannotJumpDirectlyToApproved(): void
+    {
+        $this->assertNotContains('approved', \KYC_TRANSITIONS['draft']);
+    }
+
+    public function testSubmittedCannotJumpDirectlyToApproved(): void
+    {
+        $this->assertNotContains('approved', \KYC_TRANSITIONS['submitted']);
+    }
+
+    public function testStatusLabelsAreAllPersian(): void
+    {
+        foreach (\KYC_STATUSES as $label) {
+            $this->assertMatchesRegularExpression('/\p{Arabic}/u', $label);
+        }
+    }
+
+    /* ---------- Feature gating (§22) ---------- */
+
+    public function testUnknownGateIsNeverRequired(): void
+    {
+        $this->assertFalse(\kyc_gate_required('not_a_real_gate'));
+    }
+
+    public function testGateOffAlwaysAllowsRegardlessOfKycStatus(): void
+    {
+        $this->assertTrue(\kyc_feature_allowed_for_status(false, 'draft'));
+        $this->assertTrue(\kyc_feature_allowed_for_status(false, 'rejected'));
+        $this->assertTrue(\kyc_feature_allowed_for_status(false, 'approved'));
+    }
+
+    public function testGateOnDeniesUntilApproved(): void
+    {
+        $this->assertFalse(\kyc_feature_allowed_for_status(true, 'draft'));
+        $this->assertFalse(\kyc_feature_allowed_for_status(true, 'submitted'));
+        $this->assertFalse(\kyc_feature_allowed_for_status(true, 'under_review'));
+        $this->assertFalse(\kyc_feature_allowed_for_status(true, 'needs_correction'));
+        $this->assertFalse(\kyc_feature_allowed_for_status(true, 'rejected'));
+    }
+
+    public function testGateOnAllowsOnceApproved(): void
+    {
+        $this->assertTrue(\kyc_feature_allowed_for_status(true, 'approved'));
+    }
+
+    public function testEveryCatalogedGateHasAPersianLabel(): void
+    {
+        foreach (\KYC_FEATURE_GATES as $label) {
+            $this->assertMatchesRegularExpression('/\p{Arabic}/u', $label);
+        }
+    }
+
+    /* ---------- Account type catalog (§1) ---------- */
+
+    public function testAccountTypesAreExactlyIndividualAndLegal(): void
+    {
+        $this->assertSame(['individual', 'legal'], array_keys(\PROFILE_ACCOUNT_TYPES));
+    }
+
+    public function testUnknownAccountTypeLabelFallsBackToIndividual(): void
+    {
+        $this->assertSame(\PROFILE_ACCOUNT_TYPES['individual'], \profile_account_type_label('not_a_type'));
+    }
+
+    /* ---------- Account-level completeness (§14) ---------- */
+
+    public function testIndividualCompletenessIsZeroWhenNothingFilled(): void
+    {
+        $userProfile = ['father_name' => '', 'national_code' => '', 'birth_certificate_no' => '', 'birth_date' => null];
+        $address = ['postal_code' => '', 'city' => ''];
+        $score = \profile_account_completeness('individual', $userProfile, [], $address);
+        $this->assertSame(0, $score['percent']);
+    }
+
+    public function testIndividualCompletenessIsFullWhenEverythingFilled(): void
+    {
+        $userProfile = ['father_name' => 'رضا', 'national_code' => '1234567890', 'birth_certificate_no' => '1', 'birth_date' => '2000-01-01'];
+        $address = ['postal_code' => '1234567890', 'city' => 'تهران'];
+        $score = \profile_account_completeness('individual', $userProfile, [], $address);
+        $this->assertSame(100, $score['percent']);
+        $this->assertSame([], $score['missing']);
+    }
+
+    public function testLegalCompletenessDelegatesToOrganizationCompleteness(): void
+    {
+        $organizationProfile = ['legal_name' => 'شرکت نمونه', 'ceo_name' => 'مدیر', 'company_type' => 'unspecified'];
+        $address = ['postal_code' => '1234567890', 'city' => 'تهران'];
+        $score = \profile_account_completeness('legal', [], $organizationProfile, $address);
+        $this->assertSame(100, $score['percent']);
+    }
+
+    /* ---------- Digit normalization (§26/§27) — reused straight from Profile.php ---------- */
+
+    public function testPersianDigitsNormalizeToAsciiForNationalCode(): void
+    {
+        $this->assertSame('1234567890', \profile_normalize_national_code('۱۲۳۴۵۶۷۸۹۰'));
+    }
+
+    public function testArabicDigitsNormalizeToAsciiForPostalCode(): void
+    {
+        $this->assertSame('1234567890', \profile_normalize_postal_code('١٢٣٤٥٦٧٨٩٠'));
+    }
+
+    public function testShortNationalCodeIsRejectedRatherThanTruncated(): void
+    {
+        $this->assertSame('', \profile_normalize_national_code('123'));
+    }
+
+    /* ---------- Allowed-IP validation (§20) ---------- */
+
+    public function testPlainIpv4IsValid(): void
+    {
+        $this->assertSame('203.0.113.10', \allowed_ip_normalize('203.0.113.10'));
+    }
+
+    public function testIpv4CidrIsValid(): void
+    {
+        $this->assertSame('203.0.113.0/24', \allowed_ip_normalize('203.0.113.0/24'));
+    }
+
+    public function testIpv6IsValid(): void
+    {
+        $this->assertSame('2001:db8::1', \allowed_ip_normalize('2001:db8::1'));
+    }
+
+    public function testIpv4CidrPrefixOutOfRangeIsRejected(): void
+    {
+        $this->assertNull(\allowed_ip_normalize('203.0.113.0/99'));
+    }
+
+    public function testGarbageIsRejected(): void
+    {
+        $this->assertNull(\allowed_ip_normalize('not-an-ip'));
+        $this->assertNull(\allowed_ip_normalize(''));
+    }
+
+    public function testPersianDigitsInIpAreNormalizedBeforeValidation(): void
+    {
+        $this->assertSame('192.168.1.1', \allowed_ip_normalize('۱۹۲.۱۶۸.۱.۱'));
+    }
+}


### PR DESCRIPTION
## Summary
- Durable `account_type` (individual/legal, حقیقی/حقوقی) on the organization profile, additive/idempotent migration with safe backfill.
- KYC state machine (`draft → submitted → under_review → approved/needs_correction/rejected`) with a single validated transition choke point.
- Per-document review status (pending/approved/rejected), platform-admin review panel (`public/kyc-review.php`), organization allowed-IP management, and a centralized `kyc_feature_allowed()` gate (off by default everywhere — no existing customer is affected).
- Full details in `docs/profile-kyc.md`.

## Test plan
- [x] `make lint` — 277 PHP files parse cleanly
- [x] `vendor/bin/phpunit` (unit) — 361/361 pass
- [x] `vendor/bin/phpunit -c phpunit.integration.xml` — 622/623 pass (the one failure, `RbacConcurrencyTest::testConcurrentLastOwnerDemotionsCannotBothSucceed`, is a pre-existing flaky concurrency race unrelated to this change, reproduced independently on this branch)
- [x] `php cron/backend-boundary-check.php` — PASS, no direct backend-table access

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01HuAMNmCLa2uuyDyBKVAkQa

---
_Generated by [Claude Code](https://claude.ai/code/session_01HuAMNmCLa2uuyDyBKVAkQa)_